### PR TITLE
Fix EZP-21670: tests fixes and refactorings

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -197,10 +197,6 @@ define(["structures/Response", "structures/Request", "structures/CAPIError"],
      * @param callback
      */
     ConnectionManager.prototype.delete = function (url, callback) {
-        // default values for all the parameters
-        url = (typeof url === "undefined") ? "/" : url;
-        callback = (typeof callback === "undefined") ? function () {} : callback;
-
         this.request(
             "DELETE",
             url,

--- a/test/CAPI.tests.js
+++ b/test/CAPI.tests.js
@@ -17,11 +17,15 @@ define(function (require) {
             anotherContentService,
             anotherContentTypeService,
             anotherUserService,
-            testOptions = {
-                logRequests: true,
-                rootPath: '/testrootpath/',
-                connectionStack: []
+            testOptions,
+            TestOptionsObject = function () {
+                this.logRequests = true;
+                this.rootPath = '/testrootpath/';
+                this.connectionStack = [];
             };
+
+        TestOptionsObject.prototype.dummyProperty = "dummy prototype property";
+        testOptions = new TestOptionsObject();
 
         beforeEach(function () {
             mockAuthenticationAgent = {

--- a/test/ConnectionManager.tests.js
+++ b/test/ConnectionManager.tests.js
@@ -335,21 +335,6 @@ define(function (require) {
                 );
             });
 
-            it("delete (with minimum arguments set)", function(){
-
-                connectionManager.delete(
-                    undefined,
-                    undefined
-                );
-
-                expect(mockAuthenticationAgent.ensureAuthentication).toHaveBeenCalled();
-                expect(mockAuthenticationAgent.authenticateRequest).toHaveBeenCalled();
-                expect(mockConnection.execute).toHaveBeenCalledWith(
-                    jasmine.any(Request),
-                    jasmine.any(Function)
-                );
-            });
-
             it("logOut", function(){
 
                 connectionManager.logOut(mockCallback);

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -289,7 +289,7 @@ define(function (require) {
                     );
 
                     updateStruct.body.ContentUpdate.Section = "/api/ezp/v2/content/sections/2";
-                    updateStruct.body.ContentUpdate.remoteId = "random-id-" + Math.random()*1000000;
+                    updateStruct.body.ContentUpdate.remoteId = "random-id-";
 
                     contentService.updateContentMetadata(
                         testContentId,
@@ -494,7 +494,7 @@ define(function (require) {
                         fieldInfo = {
                             "fieldDefinitionIdentifier": "title",
                             "languageCode": "eng-US",
-                            "fieldValue": "This is a new title" + Math.random()*1000000
+                            "fieldValue": "This is a new title"
                         };
 
                     contentUpdateStruct.body.VersionUpdate.fields.field.push(fieldInfo);
@@ -790,7 +790,7 @@ define(function (require) {
 
                 it("updateLocation", function () {
                     var locationUpdateStruct = contentService.newLocationUpdateStruct();
-                    locationUpdateStruct.remoteId = "random-remote-id-" + Math.random()*100000;
+                    locationUpdateStruct.remoteId = "random-remote-id-";
 
                     contentService.updateLocation(
                         testLocation,
@@ -998,8 +998,8 @@ define(function (require) {
 
                 it("createSection", function () {
                     var sectionInputStruct = contentService.newSectionInputStruct(
-                        "testSection" + Math.random()*1000000,
-                        "Test Section " + Math.round(Math.random()*1000)
+                        "testSection",
+                        "Test Section"
                     );
 
                     contentService.createSection(
@@ -1020,8 +1020,8 @@ define(function (require) {
 
                 it("updateSection", function () {
                     var sectionInputStruct = new SectionInputStruct(
-                        "testSection" + Math.random()*1000000,
-                        "Test Section " + Math.round(Math.random()*1000)
+                        "testSection",
+                        "Test Section"
                     );
 
                     contentService.updateSection(
@@ -1234,12 +1234,12 @@ define(function (require) {
 
                 it("createObjectStateGroup", function () {
                     var objectStateGroupCreateStruct = contentService.newObjectStateGroupCreateStruct(
-                        "some-id" + Math.random(10000),
+                        "some-id",
                         "eng-US",
                         [
                             {
                                 "_languageCode":"eng-US",
-                                "#text":"Some Name " + Math.random(10000)
+                                "#text":"Some Name"
                             }
                         ]
                     );
@@ -1263,7 +1263,7 @@ define(function (require) {
                 it("updateObjectStateGroup", function () {
                     var objectStateGroupUpdateStruct = contentService.newObjectStateGroupUpdateStruct();
 
-                    objectStateGroupUpdateStruct.body.ObjectStateGroupUpdate.identifier = "some-id" + Math.random(10000);
+                    objectStateGroupUpdateStruct.body.ObjectStateGroupUpdate.identifier = "some-id";
 
                     contentService.updateObjectStateGroup(
                         testObjectStateGroup,
@@ -1333,13 +1333,13 @@ define(function (require) {
 
                 it("createObjectState", function () {
                     var objectStateCreateStruct = contentService.newObjectStateCreateStruct(
-                        "some-id" + Math.random(10000),
+                        "some-id",
                         "eng-US",
                         0,
                         [
                             {
                                 "_languageCode":"eng-US",
-                                "#text":"Some Name " + Math.random(10000)
+                                "#text":"Some Name"
                             }
                         ],
                         []
@@ -1363,7 +1363,7 @@ define(function (require) {
                 it("updateObjectState", function () {
                     var objectStateUpdateStruct = contentService.newObjectStateUpdateStruct();
 
-                    objectStateUpdateStruct.body.ObjectStateUpdate.identifier = "some-id" + Math.random(10000);
+                    objectStateUpdateStruct.body.ObjectStateUpdate.identifier = "some-id";
 
                     contentService.updateObjectState(
                         testObjectState,
@@ -1579,7 +1579,7 @@ define(function (require) {
 
                 it("createUrlWildCard", function () {
                     var urlWildcardCreateStruct = contentService.newUrlWildcardCreateStruct(
-                            "some-new-wildcard-" + Math.random(100) * 1000,
+                            "some-new-wildcard",
                             "testLocation",
                             "false"
                         );
@@ -1827,8 +1827,8 @@ define(function (require) {
 
             it("createSection", function () {
                 var sectionInputStruct = new SectionInputStruct(
-                    "testSection" + Math.random()*1000000,
-                    "Test Section " + Math.round(Math.random()*1000)
+                    "testSection",
+                    "Test Section"
                 );
 
                 contentService.createSection(

--- a/test/ContentTypeService.tests.js
+++ b/test/ContentTypeService.tests.js
@@ -51,7 +51,7 @@ define(function (require) {
     // ******************************
     // Cases without errors
     // ******************************
-        describe("is calling injected objects with right arguments while running calls", function () {
+        describe("is calling injected objects with right arguments while performing", function () {
 
             // ******************************
             // Faked internal service calls
@@ -118,7 +118,7 @@ define(function (require) {
             it("createContentTypeGroup", function () {
 
                 var contentTypeGroupCreateStruct = contentTypeService.newContentTypeGroupInputStruct(
-                    "some-group-id" + Math.random(100)
+                    "some-group-id"
                 );
 
                 contentTypeService.createContentTypeGroup(
@@ -191,7 +191,7 @@ define(function (require) {
             it("updateContentTypeGroup", function () {
 
                 var contentTypeGroupUpdateStruct = contentTypeService.newContentTypeGroupInputStruct(
-                    "some-group-id" + Math.random(100)
+                    "some-group-id"
                 );
 
                 contentTypeService.updateContentTypeGroup(
@@ -251,24 +251,24 @@ define(function (require) {
                     fieldDefinition;
 
                 contentTypeCreateStruct = contentTypeService.newContentTypeCreateStruct(
-                    "content-type-id-" + Math.random(100),
+                    "content-type-id",
                     "eng-US",
                     [
                         {
                             "_languageCode":"eng-US",
-                            "#text":"Some Name " + Math.random(10000)
+                            "#text":"Some Name"
                         }
                     ]
                 );
 
                 fieldDefinition = contentTypeService.newFieldDefinitionCreateStruct(
-                    "fd-id-" + Math.random(100),
+                    "fd-id",
                     "ezstring",
                     "content",
                     [
                         {
                             "_languageCode":"eng-US",
-                            "#text":"Some FD Name " + Math.random(10000)
+                            "#text":"Some FD Name"
                         }
                     ]
                 );
@@ -298,24 +298,24 @@ define(function (require) {
                     fieldDefinition;
 
                 contentTypeCreateStruct = contentTypeService.newContentTypeCreateStruct(
-                    "content-type-id-" + Math.random(100),
+                    "content-type-id",
                     "eng-US",
                     [
                         {
                             "_languageCode":"eng-US",
-                            "#text":"Some Name " + Math.random(10000)
+                            "#text":"Some Name"
                         }
                     ]
                 );
 
                 fieldDefinition = contentTypeService.newFieldDefinitionCreateStruct(
-                    "fd-id-" + Math.random(100),
+                    "fd-id",
                     "ezstring",
                     "content",
                     [
                         {
                             "_languageCode":"eng-US",
-                            "#text":"Some FD Name " + Math.random(10000)
+                            "#text":"Some FD Name"
                         }
                     ]
                 );
@@ -453,7 +453,7 @@ define(function (require) {
                 contentTypeUpdateStruct.names.value = [
                     {
                         "_languageCode":"eng-US",
-                        "#text":"Some new FD Name " + Math.random(10000)
+                        "#text":"Some new FD Name"
                     }
                 ];
 
@@ -494,7 +494,7 @@ define(function (require) {
                 contentTypeUpdateStruct.names.value = [
                     {
                         "_languageCode":"eng-US",
-                        "#text":"Some new FD Name " + Math.random(10000)
+                        "#text":"Some new FD Name"
                     }
                 ];
 
@@ -546,13 +546,13 @@ define(function (require) {
                 spyOn(contentTypeService, 'loadContentTypeDraft').andCallFake(fakedLoadContentTypeDraft);
 
                 var fieldDefinitionCreateStruct = contentTypeService.newFieldDefinitionCreateStruct(
-                    "fd-id-" + Math.random(100),
+                    "fd-id",
                     "ezstring",
                     "content",
                     [
                         {
                             "_languageCode":"eng-US",
-                            "#text":"Some FD Name " + Math.random(10000)
+                            "#text":"Some FD Name"
                         }
                     ]
                 );
@@ -623,7 +623,7 @@ define(function (require) {
             // ******************************
             // Structures
             // ******************************
-            describe("creating structures", function () {
+            describe("structures creation", function () {
 
                 it("newContentTypeGroupInputStruct", function(){
 
@@ -733,7 +733,7 @@ define(function (require) {
 
             });
 
-            describe("dealing with faulty inner calls", function(){
+            describe("dealing with faulty inner calls and performing", function(){
 
                 beforeEach(function (){
                     discoveryService = new DiscoveryService(
@@ -764,24 +764,24 @@ define(function (require) {
                         fieldDefinition;
 
                     contentTypeCreateStruct = contentTypeService.newContentTypeCreateStruct(
-                        "content-type-id-" + Math.random(100),
+                        "content-type-id",
                         "eng-US",
                         [
                             {
                                 "_languageCode":"eng-US",
-                                "#text":"Some Name " + Math.random(10000)
+                                "#text":"Some Name"
                             }
                         ]
                     );
 
                     fieldDefinition = contentTypeService.newFieldDefinitionCreateStruct(
-                        "fd-id-" + Math.random(100),
+                        "fd-id",
                         "ezstring",
                         "content",
                         [
                             {
                                 "_languageCode":"eng-US",
-                                "#text":"Some FD Name " + Math.random(10000)
+                                "#text":"Some FD Name"
                             }
                         ]
                     );
@@ -805,13 +805,13 @@ define(function (require) {
                     spyOn(contentTypeService, 'loadContentTypeDraft').andCallFake(fakedFaultyLoadContentTypeDraft);
 
                     var fieldDefinitionCreateStruct = contentTypeService.newFieldDefinitionCreateStruct(
-                        "fd-id-" + Math.random(100),
+                        "fd-id",
                         "ezstring",
                         "content",
                         [
                             {
                                 "_languageCode":"eng-US",
-                                "#text":"Some FD Name " + Math.random(10000)
+                                "#text":"Some FD Name"
                             }
                         ]
                     );

--- a/test/DiscoveryService.tests.js
+++ b/test/DiscoveryService.tests.js
@@ -88,10 +88,16 @@ define(function (require) {
             });
 
             it("copyToCache", function(){
+                var TestObject = function () {
+                    this.trash = testTrashObject;
+                };
 
-                discoveryService.copyToCache({"trash": testTrashObject});
+                TestObject.prototype.dummyProperty = "prototype dummy property";
+
+                discoveryService.copyToCache(new TestObject());
 
                 expect(discoveryService.cacheObject.trash).toEqual(testTrashObject);
+                expect(discoveryService.cacheObject.dummyProperty).toBeUndefined();
             });
 
             it("getObjectFromCache", function(){

--- a/test/HttpBasicAuthAgent.tests.js
+++ b/test/HttpBasicAuthAgent.tests.js
@@ -8,6 +8,7 @@ define(function (require) {
 
         var testLogin = "login",
             testPassword = "password",
+            mockCAPI = {},
             mockCallback,
             mockRequest,
             httpBasicAuthAgent;
@@ -16,7 +17,7 @@ define(function (require) {
             mockCallback = jasmine.createSpy('mockCallback');
         });
 
-        describe("is correctly performing calls:", function(){
+        describe("is correctly performing", function(){
 
             beforeEach(function (){
 
@@ -44,6 +45,10 @@ define(function (require) {
                 expect(mockRequest.httpBasicAuth).toEqual(true);
                 expect(mockRequest.login).toEqual(testLogin);
                 expect(mockRequest.password).toEqual(testPassword);
+            });
+
+            it("setCAPI (which does exactly nothing for this very agent, but should be present for uniformity)", function(){
+                httpBasicAuthAgent.setCAPI(mockCAPI);
             });
 
             it("logOut", function(){

--- a/test/MicrosoftXmlHttpRequestConnection.tests.js
+++ b/test/MicrosoftXmlHttpRequestConnection.tests.js
@@ -11,16 +11,25 @@ define(function (require) {
         var connection,
             mockCallback,
             mockXMLHttpRequest,
-            mockRequest = {
-                body : { testBody : ""},
-                headers : { testHeader : "testHeaderValue"},
-                httpBasicAuth : false,
-                method : "GET",
-                url : "/"
-            },
+            mockRequest,
+            HeadersObject,
             testLogin = "login",
             testPassword = "password",
             testErrorCode = 400;
+
+        HeadersObject = function () {
+            this.testHeader = "testHeaderValue";
+        };
+        HeadersObject.prototype.dummyProperty = "prototype dummy property";
+
+        mockRequest = {
+            body : { testBody : ""},
+            headers : new HeadersObject(),
+            httpBasicAuth : false,
+            method : "GET",
+            url : "/"
+        };
+
 
         beforeEach(function (){
 

--- a/test/Request.tests.js
+++ b/test/Request.tests.js
@@ -1,0 +1,25 @@
+/* global define, describe, it, expect */
+define(function (require) {
+
+    // Declaring dependencies
+    var Request = require("structures/Request");
+
+    describe("Request", function () {
+
+        var TestWrapperObject = function () {
+            this.body = "body";
+        },
+        request;
+
+        TestWrapperObject.prototype.dummyProperty = "prototype dummy property";
+
+        it("is running constructor correctly", function(){
+
+            request = new Request(new TestWrapperObject());
+
+            expect(request.body).toEqual("body");
+        });
+
+    });
+
+});

--- a/test/Response.tests.js
+++ b/test/Response.tests.js
@@ -12,18 +12,21 @@ define(function (require) {
             testRootObject = {
                 "Root": testRootInnerObject
             },
+            TestWrapperObject = function () {
+                this.body = JSON.stringify(testRootObject);
+            },
             response;
+
+        TestWrapperObject.prototype.dummyProperty = "prototype dummy property";
 
         it("is parsing it's 'body' property (JSON string) into structured 'document' property", function(){
 
-            response = new Response({
-                body : JSON.stringify(testRootObject)
-            });
+            response = new Response(new TestWrapperObject());
 
             expect(response.document.Root).toEqual(testRootInnerObject);
         });
 
-        it("has correct default value for 'document' property", function(){
+        it("has correct default value for the 'document' property", function(){
 
             response = new Response({});
 

--- a/test/SessionAuthAgent.tests.js
+++ b/test/SessionAuthAgent.tests.js
@@ -224,7 +224,7 @@ define(function (require) {
 
         });
 
-        describe("is returning errors correctly, when user service fails, while performing:", function(){
+        describe("is returning errors correctly, when user service fails, while performing", function(){
 
             beforeEach(function (){
                 mockFaultyUserService = {

--- a/test/UserService.tests.js
+++ b/test/UserService.tests.js
@@ -70,7 +70,7 @@ define(function (require) {
     // ******************************
     // Cases without errors
     // ******************************
-        describe("is calling injected objects with right arguments while running calls", function () {
+        describe("is calling injected objects with right arguments while performing", function () {
 
             // ******************************
             // Faked internal service calls
@@ -280,12 +280,12 @@ define(function (require) {
                     {
                         fieldDefinitionIdentifier : "name",
                         languageCode : "eng-US",
-                        fieldValue : "UserGroup" + Math.random(100)
+                        fieldValue : "UserGroup"
                     },
                     {
                         fieldDefinitionIdentifier : "description",
                         languageCode : "eng-US",
-                        fieldValue : "This is the random description of the user group" + Math.random(100)
+                        fieldValue : "This is the random description of the user group"
                     }
                 ];
 
@@ -489,7 +489,7 @@ define(function (require) {
             it("createRole", function () {
 
                 var roleCreateStruct = userService.newRoleInputStruct(
-                    "random-role-id-" + Math.random()
+                    "random-role-id"
                 );
 
                 userService.createRole(
@@ -614,7 +614,7 @@ define(function (require) {
             it("updateRole", function () {
 
                 var roleUpdateStruct = userService.newRoleInputStruct(
-                    "random-role-id-" + Math.random()
+                    "random-role-id"
                 );
 
                 userService.updateRole(
@@ -972,7 +972,7 @@ define(function (require) {
             // ******************************
             // Structures
             // ******************************
-            describe("creating structures", function () {
+            describe("structures creation", function () {
 
                 it("newSessionCreateStruct", function(){
 
@@ -1107,7 +1107,7 @@ define(function (require) {
                     );
                 };
 
-            describe("dealing with faulty Discovery Service and running", function(){
+            describe("dealing with faulty Discovery Service and performing", function(){
 
                 beforeEach(function(){
 
@@ -1145,7 +1145,7 @@ define(function (require) {
                 it("createRole", function () {
 
                     var roleCreateStruct = userService.newRoleInputStruct(
-                        "random-role-id-" + Math.random()
+                        "random-role-id"
                     );
 
                     userService.createRole(
@@ -1181,7 +1181,7 @@ define(function (require) {
             });
 
 
-            describe("dealing with faulty inner calls", function(){
+            describe("dealing with faulty inner calls and performing", function(){
 
                 beforeEach(function (){
                     userService = new UserService(

--- a/test/XmlHttpRequestConnection.tests.js
+++ b/test/XmlHttpRequestConnection.tests.js
@@ -12,16 +12,24 @@ define(function (require) {
         var connection,
             mockCallback,
             mockXMLHttpRequest,
-            mockRequest = {
-                body : { testBody : ""},
-                headers : { testHeader : "testHeaderValue"},
-                httpBasicAuth : false,
-                method : "GET",
-                url : "/"
-            },
+            mockRequest,
+            HeadersObject,
             testLogin = "login",
             testPassword = "password",
             testErrorCode = 400;
+
+        HeadersObject = function () {
+            this.testHeader = "testHeaderValue";
+        };
+        HeadersObject.prototype.dummyProperty = "prototype dummy property";
+
+        mockRequest = {
+            body : { testBody : ""},
+            headers : new HeadersObject(),
+            httpBasicAuth : false,
+            method : "GET",
+            url : "/"
+        };
 
         beforeEach(function (){
 


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-21670

Mostly done.
One point where I'm not sure how to proceed is this one:

> > Usage of sinon.js in combination with Chai.js and sinon-chai could allow for more readable expectations. An alternative would be to create a bunch of own jasmine Matchers to test things like calls to the mocked connection manager.

@dpobel do you have any ideas in what exact way expectations readability could be improved?
