### PR TITLE
Fix EZP-21835: Missing documentation crosslinks on ez-js-rest-api

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -1043,12 +1043,21 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
 // ******************************
 
     /**
-     * Creates a new view
+     * Creates a new view. Views are used to perform content queries by certain criteria.
      *
      * @method createView
      * @param viewCreateStruct {ViewCreateStruct} object describing new view to be created
      * @param callback {Function} callback executed after performing the request (see
      *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
+     * @example
+     *     var viewCreateStruct = contentService.newViewCreateStruct('some-test-id');
+     *     viewCreateStruct.body.ViewInput.Query.Criteria = {
+     *         FullTextCriterion : "title"
+     *     };
+     *     contentService.createView(
+     *         viewCreateStruct,
+     *         callback
+     *     );
      */
     ContentService.prototype.createView = function (viewCreateStruct, callback) {
         var that = this;

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -98,7 +98,8 @@ define(['structures/SessionCreateStruct', 'structures/UserCreateStruct', 'struct
      * @param login {String} login for a new user
      * @param email {String} email for a new user
      * @param password {String} password for a new user
-     * @param fields {Array} fields array (see example for "newUserGroupCreateStruct")
+     * @param fields {Array} fields array (see example for
+     * {{#crossLink "UserService/newUserGroupCreateStruct"}}UserService.newUserGroupCreateStruct{{/crossLink}})
      * @return {UserCreateStruct}
      */
     UserService.prototype.newUserCreateStruct = function (languageCode, login, email, password, fields) {

--- a/src/structures/ContentCreateStruct.js
+++ b/src/structures/ContentCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Content object. See ContentService.createContent() call
+     * Returns a structure used to create a new Content object. See
+     * {{#crossLink "ContentService/createContent"}}ContentService.createContent{{/crossLink}}
      *
      * @class ContentCreateStruct
      * @constructor

--- a/src/structures/ContentMetadataUpdateStruct.js
+++ b/src/structures/ContentMetadataUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Content's metadata. See ContentService.updateContentMetadata() call
+     * Returns a structure used to update a Content's metadata. See
+     * {{#crossLink "ContentService/updateContentMetadata"}}ContentService.updateContentMetadata{{/crossLink}}
      *
      * @class ContentMetadataUpdateStruct
      * @constructor

--- a/src/structures/ContentTypeCreateStruct.js
+++ b/src/structures/ContentTypeCreateStruct.js
@@ -3,13 +3,15 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Content Type object. See ContentTypeService.createContentType() call
+     * Returns a structure used to create a new Content Type object. See
+     * {{#crossLink "ContentTypeService/createContentType"}}ContentTypeService.createContentType{{/crossLink}}
      *
      * @class ContentTypeCreateStruct
      * @constructor
      * @param identifier {String} Unique identifier for the target Content Type (e.g. "my_new_content_type")
      * @param languageCode {String} The language code (e.g. "eng-GB")
-     * @param names {Array} Multi language value (see example in ContentTypeService.newContentTypeCreateStruct() doc)
+     * @param names {Array} Multi language value (see example in
+     * {{#crossLink "ContentTypeService/newContentTypeCreateStruct"}}ContentTypeService:newContentTypeCreateStruct{{/crossLink}})
      */
     var ContentTypeCreateStruct = function (identifier, languageCode, names) {
         var now = JSON.parse(JSON.stringify(new Date()));

--- a/src/structures/ContentTypeGroupInputStruct.js
+++ b/src/structures/ContentTypeGroupInputStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create and update a Content Type group. See ContentTypeService.createContentTypeGroup() call
+     * Returns a structure used to create and update a Content Type group. See
+     * {{#crossLink "ContentTypeService/createContentTypeGroup"}}ContentTypeService.createContentTypeGroup{{/crossLink}}
      *
      * @class ContentTypeGroupInputStruct
      * @constructor

--- a/src/structures/ContentTypeUpdateStruct.js
+++ b/src/structures/ContentTypeUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Content Type object. See ContentTypeService.updateContentType() call
+     * Returns a structure used to update a Content Type object. See for ex.
+     * {{#crossLink "ContentTypeService/createContentTypeDraft"}}ContentTypeService.createContentTypeDraft{{/crossLink}}
      *
      * @class ContentTypeUpdateStruct
      * @constructor

--- a/src/structures/ContentUpdateStruct.js
+++ b/src/structures/ContentUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Content object. See ContentService.updateContent() call
+     * Returns a structure used to update a Content object. See
+     * {{#crossLink "ContentService/updateContent"}}ContentService.updateContent{{/crossLink}}
      *
      * @class ContentUpdateStruct
      * @constructor

--- a/src/structures/FieldDefinitionCreateStruct.js
+++ b/src/structures/FieldDefinitionCreateStruct.js
@@ -3,14 +3,16 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Field Definition. See ContentTypeService.addFieldDefinition() call
+     * Returns a structure used to create a new Field Definition. See
+     * {{#crossLink "ContentTypeService/addFieldDefinition"}}ContentTypeService.addFieldDefinition{{/crossLink}}
      *
      * @class FieldDefinitionCreateStruct
      * @constructor
      * @param identifier {String} unique field definiton identifer (e.g. "my-field")
      * @param fieldType {String} identifier of existing field type (e.g. "ezstring", "ezdate")
      * @param fieldGroup {String} identifier of existing field group (e.g. "content", "meta")
-     * @param names {Array} Multi language value (see example in ContentTypeService.newFieldDefintionCreateStruct() doc)
+     * @param names {Array} Multi language value (see example in
+     * {{#crossLink "ContentTypeService/newFieldDefinitionCreateStruct"}}ContentTypeService.newFieldDefintionCreateStruct{{/crossLink}})
      */
     var FieldDefinitionCreateStruct = function (identifier, fieldType, fieldGroup, names) {
         this.body = {};

--- a/src/structures/FieldDefinitionUpdateStruct.js
+++ b/src/structures/FieldDefinitionUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Field Definition. See ContentTypeService.updateFieldDefinition() call
+     * Returns a structure used to update a Field Definition. See
+     * {{#crossLink "ContentTypeService/updateFieldDefinition"}}ContentTypeService.updateFieldDefinition{{/crossLink}}
      *
      * @class FieldDefinitionUpdateStruct
      * @constructor

--- a/src/structures/LocationCreateStruct.js
+++ b/src/structures/LocationCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Location. See ContentService.createLocation() call
+     * Returns a structure used to create a new Location. See
+     * {{#crossLink "ContentService/createLocation"}}ContentService.createLocation{{/crossLink}}
      *
      * @class LocationCreateStruct
      * @constructor

--- a/src/structures/LocationUpdateStruct.js
+++ b/src/structures/LocationUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Location. See ContentService.updateLocation() call
+     * Returns a structure used to update a Location. See
+     * {{#crossLink "ContentService/updateLocation"}}ContentService.updateLocation{{/crossLink}}
      *
      * @class LocationUpdateStruct
      * @constructor

--- a/src/structures/ObjectStateCreateStruct.js
+++ b/src/structures/ObjectStateCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Object State. See ContentService.createObjectState() call
+     * Returns a structure used to create a new Object State. See
+     * {{#crossLink "ContentService/createObjectState"}}ContentService.createObjectState{{/crossLink}}
      *
      * @class ObjectStateCreateStruct
      * @constructor

--- a/src/structures/ObjectStateGroupCreateStruct.js
+++ b/src/structures/ObjectStateGroupCreateStruct.js
@@ -3,13 +3,14 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Object State group. See ContentService.createObjectStateGroup() call
+     * Returns a structure used to create a new Object State group. See
+     * {{#crossLink "ContentService/createObjectStateGroup"}}ContentService.createObjectStateGroup{{/crossLink}}
      *
      * @class ObjectStateGroupCreateStruct
      * @constructor
      * @param identifier {String} unique ObjectStateGroup identifier
      * @param languageCode {String} The language code (eng-GB, fre-FR, ...)
-     * @param names {Array} multiLanguageValuesType in JSON format
+     * @param names {Array} Multi language value (see the example)
      * @example
      *      var objectStateGroupCreateStruct = contentService.newObjectStateGroupCreateStruct(
      *          "some-id",

--- a/src/structures/ObjectStateGroupUpdateStruct.js
+++ b/src/structures/ObjectStateGroupUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update an Object State group. See ContentService.updateObjectStateGroup() call
+     * Returns a structure used to update an Object State group. See
+     * {{#crossLink "ContentService/updateObjectStateGroup"}}ContentService.updateObjectStateGroup{{/crossLink}}
      *
      * @class ObjectStateGroupUpdateStruct
      * @constructor

--- a/src/structures/ObjectStateUpdateStruct.js
+++ b/src/structures/ObjectStateUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update an Object State. See ContentService.updateObjectState() call
+     * Returns a structure used to update an Object State. See
+     * {{#crossLink "ContentService/updateObjectState"}}ContentService.updateObjectState{{/crossLink}}
      *
      * @class ObjectStateUpdateStruct
      * @constructor

--- a/src/structures/PolicyCreateStruct.js
+++ b/src/structures/PolicyCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Policy. See UserService.createPolicy() call
+     * Returns a structure used to create a new Policy. See
+     * {{#crossLink "UserService/addPolicy"}}UserService.addPolicy{{/crossLink}}
      *
      * @class PolicyCreateStruct
      * @constructor

--- a/src/structures/PolicyUpdateStruct.js
+++ b/src/structures/PolicyUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Policy. See UserService.updatePolicy() call
+     * Returns a structure used to update a Policy. See
+     * {{#crossLink "UserService/updatePolicy"}}UserService.updatePolicy{{/crossLink}}
      *
      * @class PolicyUpdateStruct
      * @constructor

--- a/src/structures/RelationCreateStruct.js
+++ b/src/structures/RelationCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Content object. See ContentService.createRelation() call
+     * Returns a structure used to create a new Content object. See
+     * {{#crossLink "ContentService/addRelation"}}ContentService.addRelation{{/crossLink}}
      *
      * @class RelationCreateStruct
      * @constructor

--- a/src/structures/RoleAssignInputStruct.js
+++ b/src/structures/RoleAssignInputStruct.js
@@ -3,12 +3,14 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create and update a Role Assign object. See for ex. UserService.assignRoleToUser() call
+     * Returns a structure used to create and update a Role Assign object. See for ex.
+     * {{#crossLink "UserService/assignRoleToUser"}}UserService.assignRoleToUser{{/crossLink}}
      *
      * @class RoleAssignInputStruct
      * @constructor
-     * @param role {Object} object representing the target role (see example)
-     * @param limitation {Object} object representing limitations for assignment (see example in UserService.newRoleAssignInputStruct() doc)
+     * @param role {Object} object representing the target role
+     * @param limitation {Object} object representing limitations for assignment (see example in
+     * {{#crossLink "UserService/newRoleAssignInputStruct"}}UserService.newRoleAssignInputStruct{{/crossLink}})
      */
     var RoleAssignInputStruct = function (role, limitation) {
         this.body = {};

--- a/src/structures/RoleInputStruct.js
+++ b/src/structures/RoleInputStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create and update a Role. See UserService.createRole() call
+     * Returns a structure used to create and update a Role. See
+     * {{#crossLink "UserService/createRole"}}UserService.createRole{{/crossLink}}
      *
      * @class RoleInputStruct
      * @constructor

--- a/src/structures/SectionInputStruct.js
+++ b/src/structures/SectionInputStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create and update a Section. See for ex. ContentService.createSection() call
+     * Returns a structure used to create and update a Section. See for ex.
+     * {{#crossLink "ContentService/createSection"}}ContentService.createSection{{/crossLink}}
      *
      * @class SectionInputStruct
      * @constructor

--- a/src/structures/SessionCreateStruct.js
+++ b/src/structures/SessionCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Session. See UserService.createSession() call
+     * Returns a structure used to create a new Session. See
+     * {{#crossLink "UserService/createSession"}}UserService.createSession{{/crossLink}}
      *
      * @class SessionCreateStruct
      * @constructor

--- a/src/structures/UrlAliasCreateStruct.js
+++ b/src/structures/UrlAliasCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new UrlAlias object. See ContentService.createUrlAlias() call
+     * Returns a structure used to create a new UrlAlias object. See
+     * {{#crossLink "ContentService/createUrlAlias"}}ContentService.createUrlAlias{{/crossLink}}
      *
      * @class UrlAliasCreateStruct
      * @constructor

--- a/src/structures/UrlWildcardCreateStruct.js
+++ b/src/structures/UrlWildcardCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new Url Wildcard object. See ContentService.createUrlWildcard() call
+     * Returns a structure used to create a new Url Wildcard object. See
+     * {{#crossLink "ContentService/createUrlWildcard"}}ContentService.createUrlWildcard{{/crossLink}}
      *
      * @class UrlWildcardCreateStruct
      * @constructor

--- a/src/structures/UserCreateStruct.js
+++ b/src/structures/UserCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new User. See UserService.createUser() call
+     * Returns a structure used to create a new User. See
+     * {{#crossLink "UserService/createUser"}}UserService.createUser{{/crossLink}}
      *
      * @class UserCreateStruct
      * @constructor
@@ -11,7 +12,8 @@ define(function () {
      * @param login {String} login for a new user
      * @param email {String} email for a new user
      * @param password {String} password for a new user
-     * @param fields {Array} fields array (see example for "newUserGroupCreateStruct")
+     * @param fields {Array} fields array (see example in
+     * {{#crossLink "UserService/newUserGroupCreateStruct"}}UserService.newUserGroupCreateStruct{{/crossLink}})
      */
     var UserCreateStruct = function (languageCode, login, email, password, fields) {
         this.body = {};

--- a/src/structures/UserGroupCreateStruct.js
+++ b/src/structures/UserGroupCreateStruct.js
@@ -3,12 +3,14 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new User group. See UserService.createUserGroup() call
+     * Returns a structure used to create a new User group. See
+     * {{#crossLink "UserService/createUserGroup"}}UserService.createUserGroup{{/crossLink}}
      *
      * @class UserGroupCreateStruct
      * @constructor
      * @param languageCode {String} The language code (eng-GB, fre-FR, ...)
-     * @param fields {Array} fields array (see example in UserService.newUserGroupCreateStruct() doc)
+     * @param fields {Array} fields array (see example in
+     * {{#crossLink "UserService/newUserGroupCreateStruct"}}UserService.newUserGroupCreateStruct{{/crossLink}})
      */
     var UserGroupCreateStruct = function (languageCode, fields) {
         this.body = {};

--- a/src/structures/UserGroupUpdateStruct.js
+++ b/src/structures/UserGroupUpdateStruct.js
@@ -3,12 +3,14 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a User group. See UserService.updateUserGroup() call
+     * Returns a structure used to update a User group. See
+     * {{#crossLink "UserService/updateUserGroup"}}UserService.updateUserGroup{{/crossLink}}
      *
      * @class UserGroupUpdateStruct
      * @constructor
      * @param languageCode {String} The language code (eng-GB, fre-FR, ...)
-     * @param fields {Array} fields array (see example in UserService.newUserGroupCreateStruct() doc)
+     * @param fields {Array} fields array (see example in
+     * {{#crossLink "UserService/newUserGroupCreateStruct"}}UserService.newUserGroupCreateStruct{{/crossLink}})
      */
     var UserGroupUpdateStruct = function (languageCode, fields) {
         this.body = {};

--- a/src/structures/UserUpdateStruct.js
+++ b/src/structures/UserUpdateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a User. See UserService.updateUser() call
+     * Returns a structure used to update a User. See
+     * {{#crossLink "UserService/updateUser"}}UserService.updateUser{{/crossLink}}
      *
      * @class UserUpdateStruct
      * @constructor

--- a/src/structures/ViewCreateStruct.js
+++ b/src/structures/ViewCreateStruct.js
@@ -3,7 +3,8 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new View. See ContentService.createView() call
+     * Returns a structure used to create a new View. See
+     * {{#crossLink "ContentService/createView"}}ContentService.createView{{/crossLink}}
      *
      * @class ViewCreateStruct
      * @constructor


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-21835

A bunch of crosslinks added all across the documentation
