### PR TITLE
EZP-23276: Added a method to manipulate the fields in the contentCreateStruct

### DIFF
--- a/src/structures/ContentCreateStruct.js
+++ b/src/structures/ContentCreateStruct.js
@@ -40,6 +40,24 @@ define(function () {
         return this;
     };
 
-    return ContentCreateStruct;
+    /**
+     * Adds a new field and its value into the structure
+     *
+     * @method addField
+     * @param id {Integer}  field id
+     * @param fieldIdentifer {String} field identifier
+     * @param fieldValue {Mixed} field value
+     *
+     * @return {ContentCreateStruct}
+     */
+    ContentCreateStruct.prototype.addField = function (fieldIdentifer, fieldValue) {
+        this.body.ContentCreate.fields.field.push({
+            fieldDefinitionIdentifier: fieldIdentifer,
+            fieldValue: fieldValue,
+        });
 
+        return this;
+    };
+
+    return ContentCreateStruct;
 });

--- a/test/ContentCreateStruct.tests.js
+++ b/test/ContentCreateStruct.tests.js
@@ -1,0 +1,29 @@
+/* global define, describe, it, expect, beforeEach */
+define(function (require) {
+    var ContentCreateStruct = require('structures/ContentCreateStruct'),
+        LocationCreateStruct = require("structures/LocationCreateStruct");
+
+    describe('ContentCreateStruct object creation', function () {
+        var parentLocationId = '/api/ezp/v2/content/locations/1/2/118',
+            language = 'en-US',
+            contentTypeId = '/api/ezp/v2/content/types/18',
+            fieldIdentifier = 'test',
+            fieldValue = 'test value',
+            locationStruct,
+            contentCreateStruct;
+
+        beforeEach(function () {
+            locationStruct = new LocationCreateStruct(parentLocationId);
+            contentCreateStruct = new ContentCreateStruct(contentTypeId, locationStruct, language);
+        });
+
+        it('should add a new field', function () {
+            contentCreateStruct.addField(fieldIdentifier, fieldValue);
+
+            expect(contentCreateStruct.body.ContentCreate.fields.field[0]).toEqual({
+                fieldDefinitionIdentifier: fieldIdentifier,
+                fieldValue: fieldValue,
+            });
+        });
+    });
+});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23276
# Description

This patch adds a method to easily add a field value in the content create struct. This PR replaces #45.
# Tests

unit tests + manual tests in https://github.com/ezsystems/PlatformUIBundle/pull/113
