### PR TITLE
Ignore 404 error when resetting storage.

### DIFF
--- a/src/authAgents/SessionAuthAgent.js
+++ b/src/authAgents/SessionAuthAgent.js
@@ -229,7 +229,7 @@ define(["structures/CAPIError", "storages/LocalStorage"], function (CAPIError, L
         userService.deleteSession(
             sessionHref,
             function (error, response) {
-                if ( !error ) {
+                if ( !error || response.status == 404 ) {
                     that._resetStorage();
                 }
                 done(error, response);


### PR DESCRIPTION
When browser restarts and session cookie is deleted, deleteSession sends session id from localStorage and gets a 404 in response. Login then does not send POST to user/sessions for a new session. I'm not sure about this solution, but works for me for now. Still leaves issue with 401 response, when logged in from another client (like Platform UI). But in that case deleting cookie/restarting browser will work. 
