### PR TITLE
EZP-24065: ContentMetadataUpdateStruct improvements

### DIFF
--- a/src/structures/ContentMetadataUpdateStruct.js
+++ b/src/structures/ContentMetadataUpdateStruct.js
@@ -10,14 +10,13 @@ define(function () {
      * @constructor
      */
     var ContentMetadataUpdateStruct = function () {
-        this.body = {'ContentUpdate': {}};
+            this.body = {'ContentUpdate': {}};
 
-        this.headers = {
-            "Accept": "application/vnd.ez.api.ContentInfo+json",
-            "Content-Type": "application/vnd.ez.api.ContentUpdate+json"
+            this.headers = {
+                "Accept": "application/vnd.ez.api.ContentInfo+json",
+                "Content-Type": "application/vnd.ez.api.ContentUpdate+json"
+            };
         };
-    };
 
     return ContentMetadataUpdateStruct;
-
 });

--- a/src/structures/ContentMetadataUpdateStruct.js
+++ b/src/structures/ContentMetadataUpdateStruct.js
@@ -3,32 +3,19 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to update a Content's metadata. See
-     * {{#crossLink "ContentService/updateContentMetadata"}}ContentService.updateContentMetadata{{/crossLink}}
+     * The Content Update structure that can be used with {{#crossLink
+     * "ContentService/updateContentMetadata"}}ContentService.updateContentMetadata{{/crossLink}}
      *
      * @class ContentMetadataUpdateStruct
      * @constructor
-     * @param languageCode {String} The language code (eng-GB, fre-FR, ...)
      */
-    var ContentMetadataUpdateStruct = function (languageCode) {
-        var now = JSON.parse(JSON.stringify(new Date()));
-
-        this.body = {};
-        this.body.ContentUpdate = {};
-
-        this.body.ContentUpdate.MainLanguageCode = languageCode;
-        this.body.ContentUpdate.Section = null;
-        this.body.ContentUpdate.alwaysAvailable = "true";
-        this.body.ContentUpdate.remoteId = null;
-        this.body.ContentUpdate.modificationDate = now;
-        this.body.ContentUpdate.publishDate = null;
+    var ContentMetadataUpdateStruct = function () {
+        this.body = {'ContentUpdate': {}};
 
         this.headers = {
             "Accept": "application/vnd.ez.api.ContentInfo+json",
             "Content-Type": "application/vnd.ez.api.ContentUpdate+json"
         };
-
-        return this;
     };
 
     return ContentMetadataUpdateStruct;

--- a/src/structures/ContentMetadataUpdateStruct.js
+++ b/src/structures/ContentMetadataUpdateStruct.js
@@ -18,5 +18,15 @@ define(function () {
             };
         };
 
+    /**
+     * Sets the section id
+     *
+     * @method setSection
+     * @param {String} sectionId the Section REST id
+     */
+    ContentMetadataUpdateStruct.prototype.setSection = function (sectionId) {
+        this.body.ContentUpdate.Section = {_href: sectionId};
+    };
+
     return ContentMetadataUpdateStruct;
 });

--- a/test/ContentMetadataUpdateStruct.tests.js
+++ b/test/ContentMetadataUpdateStruct.tests.js
@@ -1,0 +1,37 @@
+/* global define, describe, it, expect, beforeEach */
+define(function (require) {
+    var ContentMetadataUpdateStruct = require('structures/ContentMetadataUpdateStruct');
+
+    describe('ContentMetadataUpdateStruct', function () {
+        var contentMetadataUpdateStruct;
+
+        beforeEach(function () {
+            contentMetadataUpdateStruct = new ContentMetadataUpdateStruct();
+        });
+
+        describe('constructor', function () {
+            it('should initialize the body', function () {
+                expect(contentMetadataUpdateStruct.body).toEqual({'ContentUpdate': {}});
+            });
+
+            it('should set the headers', function () {
+                expect(contentMetadataUpdateStruct.headers).toEqual({
+                    "Accept": "application/vnd.ez.api.ContentInfo+json",
+                    "Content-Type": "application/vnd.ez.api.ContentUpdate+json"
+                });
+            });
+        });
+
+        describe('setSection', function () {
+            it('should set the Section property', function () {
+                var sectionId = 'section-id';
+
+                contentMetadataUpdateStruct.setSection(sectionId);
+
+                expect(contentMetadataUpdateStruct.body.ContentUpdate.Section).toEqual({
+                    _href: sectionId,
+                });
+            });
+        });
+    });
+});

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -304,9 +304,7 @@ define(function (require) {
 
                 it("updateContentMetadata", function () {
 
-                    var updateStruct = contentService.newContentMetadataUpdateStruct(
-                        "eng-US"
-                    );
+                    var updateStruct = contentService.newContentMetadataUpdateStruct();
 
                     updateStruct.body.ContentUpdate.Section = "/api/ezp/v2/content/sections/2";
                     updateStruct.body.ContentUpdate.remoteId = "random-id-";
@@ -1690,12 +1688,10 @@ define(function (require) {
 
                 it("newContentMetadataUpdateStruct", function (){
 
-                    testStructure = contentService.newContentMetadataUpdateStruct(
-                        testLanguage
-                    );
+                    testStructure = contentService.newContentMetadataUpdateStruct();
 
                     expect(testStructure).toEqual(jasmine.any(ContentMetadataUpdateStruct));
-                    expect(testStructure.body.ContentUpdate.MainLanguageCode).toEqual(testLanguage);
+                    expect(testStructure.body).toEqual({ContentUpdate: {}});
                 });
 
                 it("newContentCreateStruct", function (){


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24065

# Description

This patch fixes some issues found while working on https://github.com/ezsystems/PlatformUIBundle/pull/210 to assign a section to a content (originally to a subtree).

Fixed issues:

* removed some hardcoded properties (!)
* added a `setSection` method to ease the usage of the struct

# Tests

manual tests + unit tests