### PR TITLE
Fixed createContentDraft error handling when omitting a versionId

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -720,6 +720,10 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
     ContentService.prototype.createContentDraft = function (contentId, versionId, callback) {
         var that = this;
 
+        if ( !callback ) {
+            callback = versionId;
+            versionId = false;
+        }
         this.loadContentInfo(
             contentId,
             function (error, contentResponse) {
@@ -730,10 +734,9 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
                     return;
                 }
 
-                if (typeof versionId !== "function") {
+                if ( versionId ) {
                     url = contentResponse.document.Content.Versions._href + "/" + versionId;
                 } else {
-                    callback = versionId;
                     url = contentResponse.document.Content.CurrentVersion._href;
                 }
 

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -2029,13 +2029,23 @@ define(function (require) {
                 expect(mockCallback).toHaveBeenCalledWith(jasmine.any(CAPIError), false);
             });
 
-            it("createContentDraft from current version", function () {
-
+            it("createContentDraft from a given version", function () {
                 spyOn(contentService, 'loadContentInfo').andCallFake(fakedFaultyLoadContentInfo);
 
                 contentService.createContentDraft(
                     testContentId,
-                    null,
+                    2,
+                    mockCallback
+                );
+
+                expect(mockCallback).toHaveBeenCalledWith(jasmine.any(CAPIError), false);
+            });
+
+            it("createContentDraft from current version", function () {
+                spyOn(contentService, 'loadContentInfo').andCallFake(fakedFaultyLoadContentInfo);
+
+                contentService.createContentDraft(
+                    testContentId,
                     mockCallback
                 );
 


### PR DESCRIPTION
Noticed this bug while working on ezsystems/PlatformUIBundle#227. `versionId` is optional but the `callback` function might be used before checking if the method was called with 3 or 2 parameters.