### PR TITLE
EZP-24187: As an editor, I want to be able to move a content (get response header)

### DIFF
--- a/src/connections/MicrosoftXmlHttpRequestConnection.js
+++ b/src/connections/MicrosoftXmlHttpRequestConnection.js
@@ -34,7 +34,8 @@ define(["structures/Response", "structures/CAPIError"], function (Response, CAPI
             response = new Response({
                 status: XHR.status,
                 headers: XHR.getAllResponseHeaders(),
-                body: XHR.responseText
+                body: XHR.responseText,
+                xhr: XHR,
             });
             if (XHR.status >= 400) {
                 callback(

--- a/src/connections/XmlHttpRequestConnection.js
+++ b/src/connections/XmlHttpRequestConnection.js
@@ -33,7 +33,8 @@ define(["structures/Response", "structures/CAPIError"], function (Response, CAPI
             response = new Response({
                 status: XHR.status,
                 headers: XHR.getAllResponseHeaders(),
-                body: XHR.responseText
+                body: XHR.responseText,
+                xhr: XHR,
             });
             if (XHR.status >= 400) {
                 callback(

--- a/src/structures/Response.js
+++ b/src/structures/Response.js
@@ -9,6 +9,15 @@ define(function () {
      */
     var Response = function (valuesContainer) {
         /**
+         * The XMLHttpRequest object
+         *
+         * @property xhr
+         * @type {XMLHttpRequest}
+         * @default null
+         */
+        this.xhr = null;
+
+        /**
          * Body of the response (most times JSON string recieved from REST service via a Connection object)
          *
          * @property body
@@ -41,6 +50,10 @@ define(function () {
         }
 
         return this;
+    };
+
+    Response.prototype.getHeader = function (header) {
+        return this.xhr.getResponseHeader(header);
     };
 
     return Response;

--- a/test/Response.tests.js
+++ b/test/Response.tests.js
@@ -1,4 +1,4 @@
-/* global define, describe, it, expect */
+/* global define, describe, it, expect, spyOn */
 define(function (require) {
 
     // Declaring dependencies
@@ -46,4 +46,17 @@ define(function (require) {
 
     });
 
+    describe("getHeader", function () {
+        it("should call getResponseHeader on the XHR object", function () {
+            var response,
+                header = 'location',
+                xhr = {getResponseHeader: function (h) {}},
+                params =  {xhr: xhr};
+
+            spyOn(xhr, 'getResponseHeader');
+            response = new Response(params);
+            response.getHeader(header);
+            expect(xhr.getResponseHeader).toHaveBeenCalledWith(header);
+        });
+    });
 });


### PR DESCRIPTION
## Description

This pull request is usefull for: https://jira.ez.no/browse/EZP-24187 . The real purpose of the pull request is to get a specific response header (in our case "location" for the "move" request), and not only a string with all the response headers.

