### PR TITLE
EZP-24384: Added the languageCodes param in loadContentInfoAndCurrentVersion

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -495,13 +495,19 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      *
      * @method loadContentInfoAndCurrentVersion
      * @param contentId {String} target content identifier (e.g. "/api/ezp/v2/content/objects/108")
+     * @param [languageCodes=false] {String} comma separated list of language codes
+     * (ie "fre-FR,eng-GB")
      * @param callback {Function} callback executed after performing the request (see
      *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
      */
-    ContentService.prototype.loadContentInfoAndCurrentVersion = function (contentId, callback) {
+    ContentService.prototype.loadContentInfoAndCurrentVersion = function (contentId, languageCodes, callback) {
+        if ( typeof languageCodes === "function" ) {
+            callback = languageCodes;
+            languageCodes = false;
+        }
         this._connectionManager.request(
             "GET",
-            contentId,
+            contentId + (languageCodes ? '?languages=' + languageCodes : ''),
             "",
             {"Accept": "application/vnd.ez.api.Content+json"},
             callback

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -354,6 +354,25 @@ define(function (require) {
                     );
                 });
 
+                it("loadContentInfoAndCurrentVersion with a languages", function () {
+                    var languages = 'fre-FR,eng-GB';
+
+                    contentService.loadContentInfoAndCurrentVersion(
+                        testContentId,
+                        languages,
+                        mockCallback
+                    );
+
+                    expect(mockConnectionManager.request).toHaveBeenCalledWith(
+                        "GET",
+                        testContentId + '?languages=' + languages,
+                        "",
+                        {Accept: "application/vnd.ez.api.Content+json"},
+                        mockCallback
+                    );
+                });
+
+
                 it("deleteContent", function () {
                     contentService.deleteContent(
                         testContentId,


### PR DESCRIPTION
JIRA: https://github.com/ezsystems/PlatformUIBundle/pull/233

# Description

In https://github.com/ezsystems/PlatformUIBundle/pull/233 we need to load the content in a given language. This patch adds the necessary parameters to `ContentService#loadContentInfoAndCurrentVersion` to do so.

# Tests

manual tests in PlatformUI + unit tests.