### PR TITLE
EZP-24758: As a developer, I want to be able to use the views 1.1

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -142,10 +142,11 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      *
      * @method newViewCreateStruct
      * @param identifier {String} unique view identifier (e.g. "my-new-view")
+     * @param [type="ContentQuery"] {String} the view type to create
      * @return {ViewCreateStruct}
      */
-    ContentService.prototype.newViewCreateStruct = function (identifier) {
-        return new ViewCreateStruct(identifier);
+    ContentService.prototype.newViewCreateStruct = function (identifier, type) {
+        return new ViewCreateStruct(identifier, type);
     };
 
     /**

--- a/src/structures/ViewCreateStruct.js
+++ b/src/structures/ViewCreateStruct.js
@@ -3,35 +3,60 @@ define(function () {
     "use strict";
 
     /**
-     * Returns a structure used to create a new View. See
+     * Returns a structure used to create a new REST View. See
      * {{#crossLink "ContentService/createView"}}ContentService.createView{{/crossLink}}
      *
      * @class ViewCreateStruct
      * @constructor
      * @param identifier {String} unique view identifier
+     * @param [type="ContentQuery"] {String} the view type to create, the REST API currently
+     * supports only "ContentQuery" or "LocationQuery".
      */
-    var ViewCreateStruct = function (identifier) {
-        this.body = {};
-        this.body.ViewInput = {};
+    var ViewCreateStruct = function (identifier, type) {
+        var query = {
+                "Criteria": {},
+                "FacetBuilders": {},
+                "SortClauses": {},
+            };
 
-        this.body.ViewInput.identifier = identifier;
-        this.body.ViewInput["public"] = false;
-        this.body.ViewInput.Query = {};
+        if ( !type ) {
+            type = "ContentQuery";
+        }
+        /**
+         * Holds the body of the view create structs
+         *
+         * @property body
+         * @type {Object}
+         * @default {
+         *     ViewInput: {
+         *         identifier: <identifier>,
+         *         public: false,
+         *         <type>: {
+         *             Criteria: {},
+         *             SortClauses: {},
+         *             FacetBuilders: {},
+         *         },
+         *     }
+         * }
+         */
+        this.body = {ViewInput: {"identifier": identifier, "public": false}};
+        this.body.ViewInput[type] = query;
 
-        this.body.ViewInput.Query.Criteria = {};
-        this.body.ViewInput.Query.offset = 0;
-        this.body.ViewInput.Query.FacetBuilders = {};
-        this.body.ViewInput.Query.SortClauses = {};
-        this.body.ViewInput.Query.spellcheck = false;
-
+        /**
+         * Holds the headers sent when creating a view
+         *
+         * @property headers
+         * @type {Object}
+         * @default {
+         *  "Accept": "application/vnd.ez.api.View+json; version=1.1",
+         *  "Content-Type": "application/vnd.ez.api.ViewInput+json; version=1.1"
+         * }
+         */
         this.headers = {
-            "Accept": "application/vnd.ez.api.View+json",
-            "Content-Type": "application/vnd.ez.api.ViewInput+json"
+            "Accept": "application/vnd.ez.api.View+json; version=1.1",
+            "Content-Type": "application/vnd.ez.api.ViewInput+json; version=1.1"
         };
-
-        return this;
     };
 
     return ViewCreateStruct;
-
 });

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -240,12 +240,7 @@ define(function (require) {
             });
 
             it("createView", function () {
-
                 var viewCreateStruct = contentService.newViewCreateStruct('some-test-id');
-
-                viewCreateStruct.body.ViewInput.Query.Criteria = {
-                    FullTextCriterion : "title"
-                };
 
                 contentService.createView(
                     viewCreateStruct,
@@ -1767,6 +1762,18 @@ define(function (require) {
                     expect(testStructure.body.ViewInput.identifier).toEqual(testIdentifier);
                 });
 
+                it("newViewCreateStruct with type parameter", function (){
+                    var queryType = 'WhateverQueryType';
+
+                    testStructure = contentService.newViewCreateStruct(
+                        testIdentifier, queryType
+                    );
+
+                    expect(testStructure).toEqual(jasmine.any(ViewCreateStruct));
+                    expect(testStructure.body.ViewInput.identifier).toEqual(testIdentifier);
+                    expect(testStructure.body.ViewInput[queryType]).toBeDefined();
+                });
+
                 it("newRelationCreateStruct", function (){
 
                     testStructure = contentService.newRelationCreateStruct(
@@ -1940,12 +1947,7 @@ define(function (require) {
             });
 
             it("createView", function () {
-
                 var viewCreateStruct = contentService.newViewCreateStruct('some-test-id');
-
-                viewCreateStruct.body.ViewInput.Query.Criteria = {
-                    FullTextCriterion : "title"
-                };
 
                 contentService.createView(
                     viewCreateStruct,

--- a/test/ViewCreateStruct.tests.js
+++ b/test/ViewCreateStruct.tests.js
@@ -1,0 +1,59 @@
+/* global define, describe, it, expect */
+define(function (require) {
+    var ViewCreateStruct = require('structures/ViewCreateStruct');
+
+    describe('ViewCreateStruct', function () {
+        describe('constructor', function () {
+            describe('identifier parameter', function () {
+                it('should set the identifier', function () {
+                    var identifier = "my-view",
+                        struct = new ViewCreateStruct(identifier),
+                        viewInput = struct.body.ViewInput;
+
+                    expect(viewInput.identifier).toEqual(identifier);
+                });
+
+            });
+
+            describe('type parameter', function () {
+                it('should be ContentQuery by default', function () {
+                    var struct = new ViewCreateStruct("my-view"),
+                        viewInput = struct.body.ViewInput;
+
+                    expect(viewInput.ContentQuery).toBeDefined();
+                });
+
+                it('should be taken into account to create the ViewInput', function () {
+                    var queryType = "WhateverQuery",
+                        struct = new ViewCreateStruct("my-view", queryType),
+                        viewInput = struct.body.ViewInput;
+
+                    expect(viewInput[queryType]).toBeDefined();
+                });
+            });
+
+            it('should set the headers', function () {
+                var struct = new ViewCreateStruct("my-view");
+
+                expect(struct.headers.Accept).toEqual("application/vnd.ez.api.View+json; version=1.1");
+                expect(struct.headers["Content-Type"]).toEqual("application/vnd.ez.api.ViewInput+json; version=1.1");
+            });
+
+            it('should define a default query structure', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput;
+
+                expect(viewInput.ContentQuery.Criteria).toEqual({});
+                expect(viewInput.ContentQuery.FacetBuilders).toEqual({});
+                expect(viewInput.ContentQuery.SortClauses).toEqual({});
+            });
+
+            it('should set the public flag to false', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput;
+
+                expect(viewInput.public).toEqual(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24758

# Description

This patch changes the `ViewCreateStruct` to be able to handle both Content search and Location search (and actually future *Something* search if any). It's a follow up of https://github.com/ezsystems/ezpublish-kernel/pull/1364 / https://jira.ez.no/browse/EZP-24671.

With this patch, it's possible to write:

```js
struct = contentService.newViewCreateStruct('test', 'LocationQuery');
struct.body.ViewInput.LocationQuery.Criteria = {
    ParentLocationIdCriterion: 2,
};
contentService.createView(struct, function (error, response) {
    console.log(error, response);
});
```

[The (lack of) API on the `ViewCreateStruct`](https://jira.ez.no/browse/EZP-24808) makes this code ugly and because of that, this patch is BC break since code like https://github.com/ezsystems/ez-js-rest-client/pull/64/files#diff-11fea144db3a03a6f5e5b08486a4c577L246 won't work anymore. I don't know if it's a problem (ez-js-client was never really released) and if so how should we handle that ?
@bdunogier @andrerom an opinion on that ?

# Tests

manual test + unit tests