### PR TITLE
EZP-24814: Removed arbitrary sort order on LocationUpdateStruct

### DIFF
--- a/src/structures/LocationUpdateStruct.js
+++ b/src/structures/LocationUpdateStruct.js
@@ -13,9 +13,6 @@ define(function () {
         this.body = {};
         this.body.LocationUpdate = {};
 
-        this.body.LocationUpdate.sortField = "PATH";
-        this.body.LocationUpdate.sortOrder = "ASC";
-
         this.headers = {
             "Accept": "application/vnd.ez.api.Location+json",
             "Content-Type": "application/vnd.ez.api.LocationUpdate+json"

--- a/test/LocationUpdateStruct.tests.js
+++ b/test/LocationUpdateStruct.tests.js
@@ -1,0 +1,21 @@
+/* global define, describe, it, expect */
+define(function (require) {
+    var LocationUpdateStruct = require('structures/LocationUpdateStruct');
+
+    describe('LocationUpdateStruct', function () {
+        describe('constructor', function () {
+            it('should set the headers', function () {
+                var struct = new LocationUpdateStruct();
+
+                expect(struct.headers.Accept).toEqual("application/vnd.ez.api.Location+json");
+                expect(struct.headers["Content-Type"]).toEqual("application/vnd.ez.api.LocationUpdate+json");
+            });
+
+            it('should set the body', function () {
+                var struct = new LocationUpdateStruct();
+
+                expect(struct.body).toEqual({LocationUpdate: {}});
+            });
+        });
+    });
+});


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-24814

## Description
Sort order was hard coded in the LocationUpdateStruct.

## Test
Added unit test for the struct.
