### PR TITLE
EZP-24815: Added a method to set main location on ContentMetadataUpdateStruct

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -84,11 +84,10 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      * Returns update structure for Content object metadata
      *
      * @method newContentMetadataUpdateStruct
-     * @param language {String} The language code (eng-GB, fre-FR, ...)
      * @return ContentMetadataUpdateStruct
      */
-    ContentService.prototype.newContentMetadataUpdateStruct = function (language) {
-        return new ContentMetadataUpdateStruct(language);
+    ContentService.prototype.newContentMetadataUpdateStruct = function () {
+        return new ContentMetadataUpdateStruct();
     };
 
     /**

--- a/src/structures/ContentMetadataUpdateStruct.js
+++ b/src/structures/ContentMetadataUpdateStruct.js
@@ -28,5 +28,15 @@ define(function () {
         this.body.ContentUpdate.Section = {_href: sectionId};
     };
 
+    /**
+     * Sets the main location id
+     *
+     * @method setMainLocation
+     * @param {String} locationId the Location REST id
+     */
+    ContentMetadataUpdateStruct.prototype.setMainLocation = function (locationId) {
+        this.body.ContentUpdate.MainLocation = {_href: locationId};
+    };
+
     return ContentMetadataUpdateStruct;
 });

--- a/test/ContentMetadataUpdateStruct.tests.js
+++ b/test/ContentMetadataUpdateStruct.tests.js
@@ -33,5 +33,17 @@ define(function (require) {
                 });
             });
         });
+
+        describe('setMainLocation', function () {
+            it('should set the MainLocation property', function () {
+                var locationId = 'location-id';
+
+                contentMetadataUpdateStruct.setMainLocation(locationId);
+
+                expect(contentMetadataUpdateStruct.body.ContentUpdate.MainLocation).toEqual({
+                    _href: locationId,
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-24815

## Description
In https://github.com/ezsystems/PlatformUIBundle/pull/357 we need to set main location for ContentMetadataUpdateStruct. This PR adds `setMainLocation(locationId)` method to do so.
It also removes `language` parameter from `ContentService.newContentMetadataUpdateStruct` method as it wasn't used.