### PR TITLE
Fix EZP-25091: "always available" flag is hardcoded to true when creating content

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -99,8 +99,8 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      * @param language {String} The language code (eng-GB, fre-FR, ...)
      * @return {ContentCreateStruct}
      */
-    ContentService.prototype.newContentCreateStruct = function (contentTypeId, locationCreateStruct, language) {
-        return new ContentCreateStruct(contentTypeId, locationCreateStruct, language);
+    ContentService.prototype.newContentCreateStruct = function (contentTypeId, locationCreateStruct, language, alwaysAvailable) {
+        return new ContentCreateStruct(contentTypeId, locationCreateStruct, language, alwaysAvailable);
     };
 
     /**

--- a/src/structures/ContentCreateStruct.js
+++ b/src/structures/ContentCreateStruct.js
@@ -12,21 +12,21 @@ define(function () {
      * @param locationCreateStruct {LocationCreateStruct} create structure for a Location object, where the new Content object will be situated
      * @param languageCode {String} The language code (e.g. "eng-GB")
      */
-    var ContentCreateStruct = function (contentTypeId, locationCreateStruct, languageCode) {
+    var ContentCreateStruct = function (contentTypeId, locationCreateStruct, languageCode, alwaysAvailable) {
         var now = JSON.parse(JSON.stringify(new Date()));
 
         this.body = {};
         this.body.ContentCreate = {};
 
         this.body.ContentCreate.ContentType = {
-                "_href": contentTypeId
-            };
+            "_href": contentTypeId
+        };
 
         this.body.ContentCreate.mainLanguageCode = languageCode;
         this.body.ContentCreate.LocationCreate = locationCreateStruct.body.LocationCreate;
 
         this.body.ContentCreate.Section = null;
-        this.body.ContentCreate.alwaysAvailable = "true";
+        this.body.ContentCreate.alwaysAvailable = alwaysAvailable;
         this.body.ContentCreate.remoteId = null;
         this.body.ContentCreate.modificationDate = now;
         this.body.ContentCreate.fields = {};

--- a/test/ContentCreateStruct.tests.js
+++ b/test/ContentCreateStruct.tests.js
@@ -9,20 +9,45 @@ define(function (require) {
             contentTypeId = '/api/ezp/v2/content/types/18',
             fieldIdentifier = 'test',
             fieldValue = 'test value',
-            locationStruct,
+            locationStruct = new LocationCreateStruct(),
             contentCreateStruct;
 
-        beforeEach(function () {
-            locationStruct = new LocationCreateStruct(parentLocationId);
-            contentCreateStruct = new ContentCreateStruct(contentTypeId, locationStruct, language);
+        describe('constructor', function () {
+            beforeEach(function () {
+                locationStruct = new LocationCreateStruct(parentLocationId);
+                contentCreateStruct = new ContentCreateStruct(contentTypeId, locationStruct, language, true);
+            });
+
+            it('should take the locationCreateStruct paremeter into account', function () {
+                expect(contentCreateStruct.body.ContentCreate.LocationCreate).toBe(locationStruct.body.LocationCreate);
+            });
+
+            it('should take the contentTypeId paremeter into account', function () {
+                expect(contentCreateStruct.body.ContentCreate.ContentType._href).toBe(contentTypeId);
+            });
+
+            it('should take the languageCode paremeter into account', function () {
+                expect(contentCreateStruct.body.ContentCreate.mainLanguageCode).toBe(language);
+            });
+
+            it('should take the alwaysAvailable paremeter into account', function () {
+                expect(contentCreateStruct.body.ContentCreate.alwaysAvailable).toBe(true);
+            });
         });
 
-        it('should add a new field', function () {
-            contentCreateStruct.addField(fieldIdentifier, fieldValue);
+        describe('addField', function () {
+            beforeEach(function () {
+                locationStruct = new LocationCreateStruct(parentLocationId);
+                contentCreateStruct = new ContentCreateStruct(contentTypeId, locationStruct, language, false);
+            });
 
-            expect(contentCreateStruct.body.ContentCreate.fields.field[0]).toEqual({
-                fieldDefinitionIdentifier: fieldIdentifier,
-                fieldValue: fieldValue,
+            it('should add a new field', function () {
+                contentCreateStruct.addField(fieldIdentifier, fieldValue);
+
+                expect(contentCreateStruct.body.ContentCreate.fields.field[0]).toEqual({
+                    fieldDefinitionIdentifier: fieldIdentifier,
+                    fieldValue: fieldValue,
+                });
             });
         });
     });

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -1713,13 +1713,15 @@ define(function (require) {
                     testStructure = contentService.newContentCreateStruct(
                         testContentTypeId,
                         testLocationCreateStruct,
-                        testLanguage
+                        testLanguage,
+                        true
                     );
 
                     expect(testStructure).toEqual(jasmine.any(ContentCreateStruct));
                     expect(testStructure.body.ContentCreate.LocationCreate).toEqual(testLocationCreateStruct.body.LocationCreate);
                     expect(testStructure.body.ContentCreate.ContentType._href).toEqual(testContentTypeId);
                     expect(testStructure.body.ContentCreate.mainLanguageCode).toEqual(testLanguage);
+                    expect(testStructure.body.ContentCreate.alwaysAvailable).toBe(true);
                 });
 
                 it("newSectionInputStruct", function (){


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25091

# Description

This patch removes the hardcoded value for the "always available" flag in the content create struct and adds a parameter to the content create struct and the `ContentService#newContentCreateStruct` method so that it's possible to set a correct value.

# Tests

unit test + manual test in PlatformUI