### PR TITLE
EZP-25258: As a developer, I want to have access to the API doc of the JavaScript REST client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ after_success:
     - if [ $TRAVIS_PULL_REQUEST != "false" ] ; then sh bin/generate_apidoc.sh ; fi
 env:
     global:
-        secure: Z0GXdVOLMJNtueamtpA9FZzeNQeX8EEaaVOLYZTKZ7XNATlrFiZHzGk4IOU6YcWjUxpLv7E03HE8yCGvTnHuUOQAXskvZsUBngDKsc/DkpvFRj1lhSPOKkUU+ClfcxtbnBfwfQz+552oxlqVwdS9ZSD6/YBaoVIeEtiLOEs6O3Y=
+        secure: MAyyZNJ9zHL2ENRZhoqD2IIlaPbFpzB+HFZsTPyA406O04sMIaJJRyVxMGmnKk7/PPt9/OdGb6lYs8pAJkZPHTf67c5CU4u/0HFFXZPnysBjhln9egLqGc/g2UkgIYcDl9d6H34HGf/5wQG1XWZeaqkLwdhPVJDiH5PT2/IBU+8=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ after_success:
     - if [ $TRAVIS_PULL_REQUEST != "false" ] ; then sh bin/generate_apidoc.sh ; fi
 env:
     global:
-        secure: MAyyZNJ9zHL2ENRZhoqD2IIlaPbFpzB+HFZsTPyA406O04sMIaJJRyVxMGmnKk7/PPt9/OdGb6lYs8pAJkZPHTf67c5CU4u/0HFFXZPnysBjhln9egLqGc/g2UkgIYcDl9d6H34HGf/5wQG1XWZeaqkLwdhPVJDiH5PT2/IBU+8=
+        secure: JO1M7asQCvew+AIXgh++vUDRKMS7S1ZLPJ1HVGPCyG1E1BjTCojwX+IJ0po1FtCWESWjPRr0kVBqLEu5J6g1Pcxx4I2bpgecfRAQS8Bhw2gn5C51OpNcJz7PFjAxg5VwaL4YmIndmInGU+YTU0J3ovLbnnlavpvYklXMXBaYe6M=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ branches:
 before_script:
     - npm install -g grunt-cli
 after_success:
-    # TODO do the opposite before merge ie generate the doc if it's not a PR
-    - if [ $TRAVIS_PULL_REQUEST != "false" ] ; then sh bin/generate_apidoc.sh ; fi
+    - if [ $TRAVIS_PULL_REQUEST = "false" ] ; then sh bin/generate_apidoc.sh ; fi
 env:
     global:
         secure: JO1M7asQCvew+AIXgh++vUDRKMS7S1ZLPJ1HVGPCyG1E1BjTCojwX+IJ0po1FtCWESWjPRr0kVBqLEu5J6g1Pcxx4I2bpgecfRAQS8Bhw2gn5C51OpNcJz7PFjAxg5VwaL4YmIndmInGU+YTU0J3ovLbnnlavpvYklXMXBaYe6M=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
+    - '0.10'
+branches:
+    only:
+        - master
 before_script:
-  - npm install -g grunt-cli
+    - npm install -g grunt-cli
+after_success:
+    # TODO do the opposite before merge ie generate the doc if it's not a PR
+    - if [ $TRAVIS_PULL_REQUEST != "false" ] ; then sh bin/generate_apidoc.sh ; fi
+env:
+    global:
+        # TODO: use an ezrobot token
+        secure: hzGZ7j6dWYbMwPkPqXHt1L4SIRMW/bO76GVMoZ/+8CH5L3pJie5TIwAssjM/1qhMAABVpSl9Bi79JOqP3nq7fT953yEM7y51OS0RPnc0dbHjyT6q23TlwJj10E4kApPUA5orgQy4eLChS/IrNrAY50bQoz+OEZv8wJHJa3Nr2Tw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ after_success:
     - if [ $TRAVIS_PULL_REQUEST != "false" ] ; then sh bin/generate_apidoc.sh ; fi
 env:
     global:
-        # TODO: use an ezrobot token
-        secure: hzGZ7j6dWYbMwPkPqXHt1L4SIRMW/bO76GVMoZ/+8CH5L3pJie5TIwAssjM/1qhMAABVpSl9Bi79JOqP3nq7fT953yEM7y51OS0RPnc0dbHjyT6q23TlwJj10E4kApPUA5orgQy4eLChS/IrNrAY50bQoz+OEZv8wJHJa3Nr2Tw=
+        secure: Z0GXdVOLMJNtueamtpA9FZzeNQeX8EEaaVOLYZTKZ7XNATlrFiZHzGk4IOU6YcWjUxpLv7E03HE8yCGvTnHuUOQAXskvZsUBngDKsc/DkpvFRj1lhSPOKkUU+ClfcxtbnBfwfQz+552oxlqVwdS9ZSD6/YBaoVIeEtiLOEs6O3Y=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function(grunt) {
         yuidoc: {
             compile: {
                 name: '<%= pkg.description %>',
-                description: 'Auto-generated doc API of the eZ Platform JavaScript REST client',
+                description: 'Auto-generated API doc of eZ Platform JavaScript REST client',
                 version: '<%= pkg.version %>',
                 url: '<%= pkg.repository %>',
                 logo: "http://ez.no/extension/ez_ezno/design/ezno_2014/images/ez-logo.png",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,8 +113,8 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
         yuidoc: {
             compile: {
-                name: '<%= pkg.name %>',
-                description: '<%= pkg.description %>',
+                name: '<%= pkg.description %>',
+                description: 'Auto-generated doc API of the eZ Platform JavaScript REST client',
                 version: '<%= pkg.version %>',
                 url: '<%= pkg.repository %>',
                 logo: "http://ez.no/extension/ez_ezno/design/ezno_2014/images/ez-logo.png",

--- a/bin/generate_apidoc.sh
+++ b/bin/generate_apidoc.sh
@@ -1,20 +1,26 @@
 #! /bin/sh
+# Script to generate the client API doc and to push the generated
+# to a repository in a given branch.
+# This script expects the $GH_TOKEN variable to be set to a valid
+# Github user token who is allowed to push on the target repository
 
 JS_REST_CLIENT_DIR="javascript-rest-client"
 TRIGGER_COMMIT_MSG=`git log --oneline -1`
-# TODO replace to ezsystems/ezsystems.github.com
+# TODO change to ezsystems/ezsystems.github.com
 DOC_REPOSITORY="dpobel/test-doc"
-# TODO replace to master
+# TODO change to master
 DOC_BRANCH=gh-pages
+GITHUB_USER="eZ Robot, I do what I'm told to..."
+# TODO change to ezrobot's email
+GITHUB_USER_EMAIL="dp@ez.no"
 
 grunt doc
 git clone https://${GH_TOKEN}@github.com/${DOC_REPOSITORY}.git ../ezsystems.github.com
 
 cd ../ezsystems.github.com
 
-git config user.name "eZ Robot, I do what I'm told to..."
-# TODO replace with ezrobot's email
-git config user.email "dp@ez.no"
+git config user.name "$GITHUB_USER"
+git config user.email "$GITHUB_USER_EMAIL"
 
 git checkout "$DOC_BRANCH"
 rsync -av --checksum $TRAVIS_BUILD_DIR/api/ "$JS_REST_CLIENT_DIR/"

--- a/bin/generate_apidoc.sh
+++ b/bin/generate_apidoc.sh
@@ -12,7 +12,7 @@ GITHUB_USER="eZ Robot, I do what I'm told to..."
 GITHUB_USER_EMAIL="ezrobot@ez.no"
 
 grunt doc
-git clone https://${GH_TOKEN}@github.com/${DOC_REPOSITORY}.git ../ezsystems.github.com
+git clone -q https://${GH_TOKEN}@github.com/${DOC_REPOSITORY}.git ../ezsystems.github.com > /dev/null
 
 cd ../ezsystems.github.com
 
@@ -28,7 +28,7 @@ if [ ! -z "$STATUS" ] ; then
     git add "$JS_REST_CLIENT_DIR"
     git commit -m "`echo "Updated JavaScript REST Client API doc\n\nAfter:\n$TRIGGER_COMMIT_MSG"`"
     git pull --rebase
-    git push origin $DOC_BRANCH
+    git push origin $DOC_BRANCH -q 2> /dev/null
 else
     echo "No change in the doc"
 fi

--- a/bin/generate_apidoc.sh
+++ b/bin/generate_apidoc.sh
@@ -1,0 +1,31 @@
+#! /bin/sh
+
+JS_REST_CLIENT_DIR="javascript-rest-client"
+TRIGGER_COMMIT_MSG=`git log --oneline -1`
+# TODO replace to ezsystems/ezsystems.github.com
+DOC_REPOSITORY="dpobel/test-doc"
+# TODO replace to master
+DOC_BRANCH=gh-pages
+
+grunt doc
+git clone https://${GH_TOKEN}@github.com/${DOC_REPOSITORY}.git ../ezsystems.github.com
+
+cd ../ezsystems.github.com
+
+git config user.name "eZ Robot, I do what I'm told to..."
+# TODO replace with ezrobot's email
+git config user.email "dp@ez.no"
+
+git checkout "$DOC_BRANCH"
+rsync -av --checksum $TRAVIS_BUILD_DIR/api/ "$JS_REST_CLIENT_DIR/"
+
+STATUS=`git status --porcelain`
+
+if [ ! -z "$STATUS" ] ; then
+    git add "$JS_REST_CLIENT_DIR"
+    git commit -m "Updated JavaScript REST Client API doc\n\nAfter:\n$TRIGGER_COMMIT_MSG"
+    git pull --rebase
+    git push origin $DOC_BRANCH
+else
+    echo "No change in the doc"
+fi

--- a/bin/generate_apidoc.sh
+++ b/bin/generate_apidoc.sh
@@ -6,13 +6,10 @@
 
 JS_REST_CLIENT_DIR="javascript-rest-client"
 TRIGGER_COMMIT_MSG=`git log --oneline -1 $TRAVIS_COMMIT`
-# TODO change to ezsystems/ezsystems.github.com
-DOC_REPOSITORY="dpobel/test-doc"
-# TODO change to master
-DOC_BRANCH=gh-pages
+DOC_REPOSITORY="ezsystems/ezsystems.github.com"
+DOC_BRANCH=master
 GITHUB_USER="eZ Robot, I do what I'm told to..."
-# TODO change to ezrobot's email
-GITHUB_USER_EMAIL="dp@ez.no"
+GITHUB_USER_EMAIL="ezrobot@ez.no"
 
 grunt doc
 git clone https://${GH_TOKEN}@github.com/${DOC_REPOSITORY}.git ../ezsystems.github.com

--- a/bin/generate_apidoc.sh
+++ b/bin/generate_apidoc.sh
@@ -5,7 +5,7 @@
 # Github user token who is allowed to push on the target repository
 
 JS_REST_CLIENT_DIR="javascript-rest-client"
-TRIGGER_COMMIT_MSG=`git log --oneline -1`
+TRIGGER_COMMIT_MSG=`git log --oneline -1 $TRAVIS_COMMIT`
 # TODO change to ezsystems/ezsystems.github.com
 DOC_REPOSITORY="dpobel/test-doc"
 # TODO change to master
@@ -29,7 +29,7 @@ STATUS=`git status --porcelain`
 
 if [ ! -z "$STATUS" ] ; then
     git add "$JS_REST_CLIENT_DIR"
-    git commit -m "Updated JavaScript REST Client API doc\n\nAfter:\n$TRIGGER_COMMIT_MSG"
+    git commit -m "`echo "Updated JavaScript REST Client API doc\n\nAfter:\n$TRIGGER_COMMIT_MSG"`"
     git pull --rebase
     git push origin $DOC_BRANCH
 else

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CAPI",
   "repository": "https://github.com/ezsystems/ez-js-rest-client",
-  "description": "JS REST Client for eZ Publish Platform",
+  "description": "eZ Platform JavaScript REST client",
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt-contrib-jshint": "~0.6.0",
     "glob": "~3.2.1",
     "grunt-shell": "~0.3.1",
-    "grunt-contrib-yuidoc": "~0.4.0",
+    "grunt-contrib-yuidoc": "~0.10.0",
     "q": "~0.9.7",
     "grunt-requirejs": "~0.4.0",
     "grunt-template-jasmine-istanbul": "~0.2.5",

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -51,8 +51,8 @@ define(['structures/SessionCreateStruct', 'structures/UserCreateStruct', 'struct
      * Returns session create structure
      *
      * @method newSessionCreateStruct
-     * @param login {String} login for a user, which wants to start a session
-     * @param password {String} password for a user, which wants to start a session
+     * @param login {String} user's login
+     * @param password {String} user's password
      * @return {SessionCreateStruct}
      */
     UserService.prototype.newSessionCreateStruct = function (login, password) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25258

# Description

This PR changes Travis configuration to generate and push the API doc.
With the current configuration, you can see the result in: http://dpobel.github.io/test-doc/javascript-rest-client/ (but this is supposed to be available at http://ezsystems.github.io/javascript-rest-client/)

## TODO before merging

* [ ] Change .travis.yml to build the doc when something happens on `master`
* [x] Really push to https://github.com/ezsystems/ezsystems.github.com
* [x] Push as @ezrobot 

# Tests

this PR :)