### PR TITLE
Fix EZP-25418: Typo in ContentService EmptyTrash()

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -1291,11 +1291,11 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
     };
 
 // ******************************
-// Thrash management
+// Trash management
 // ******************************
 
     /**
-     *  Loads all the thrash can items
+     *  Loads all the trash can items
      *
      * @method loadTrashItems
      * @param [limit=-1] {Number} the number of results returned
@@ -1345,7 +1345,7 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
     };
 
     /**
-     *  Loads target thrash can item
+     *  Loads target trash can item
      *
      * @method loadTrashItem
      * @param trashItemId {String} target trash item identifier (e.g. "/api/ezp/v2/content/trash/1")
@@ -1414,8 +1414,25 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      * @method emptyThrash
      * @param callback {Function} callback executed after performing the request (see
      *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
+     * @deprecated since 1.1 and will be removed in 2.0. Is replaced `emptyTrash` which has the same behavior
+     *
      */
     ContentService.prototype.emptyThrash = function (callback) {
+        console.warn('[DEPRECATED] ContentService.emptyThrash is deprecated');
+        console.warn('[DEPRECATED] ContentService.emptyThrash is deprecated will be removed in eZ JS REST client 2.0');
+        console.warn('[DEPRECATED] use ContentService.emptyTrash instead');
+
+        this.emptyTrash(callback);
+    };
+
+    /**
+     *  Empty the trash can
+     *
+     * @method emptyTrash
+     * @param callback {Function} callback executed after performing the request (see
+     *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
+     */
+    ContentService.prototype.emptyTrash = function (callback) {
         var that = this;
 
         this._discoveryService.getInfoObject(

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -1162,7 +1162,7 @@ define(function (require) {
             });
 
             // ******************************
-            // Thrash management
+            // Trash management
             // ******************************
             describe("Trash management request:", function () {
 
@@ -1279,7 +1279,7 @@ define(function (require) {
                     );
                 });
 
-                it("emptyTrash", function () {
+                it("emptyThrash", function () {
                     contentService.emptyThrash(
                         mockCallback
                     );
@@ -1293,7 +1293,22 @@ define(function (require) {
                         {},
                         mockCallback
                     );
+                });
 
+                it("emptyTrash", function () {
+                    contentService.emptyTrash(
+                        mockCallback
+                    );
+
+                    expect(mockDiscoveryService.getInfoObject).toHaveBeenCalledWith("trash", jasmine.any(Function));
+
+                    expect(mockConnectionManager.request).toHaveBeenCalledWith(
+                        "DELETE",
+                        trash,
+                        "",
+                        {},
+                        mockCallback
+                    );
                 });
 
             });
@@ -2002,8 +2017,17 @@ define(function (require) {
                 expect(mockCallback).toHaveBeenCalledWith(jasmine.any(CAPIError), errorResponse);
             });
 
-            it("emptyTrash", function () {
+            it("emptyThrash", function () {
                 contentService.emptyThrash(
+                    mockCallback
+                );
+
+                expect(mockFaultyDiscoveryService.getInfoObject).toHaveBeenCalledWith("trash", jasmine.any(Function));
+                expect(mockCallback).toHaveBeenCalledWith(jasmine.any(CAPIError), errorResponse);
+            });
+
+            it("emptyTrash", function () {
+                contentService.emptyTrash(
                     mockCallback
                 );
 


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25418

## Description
There was a typo in the name of the method. I changed it, and removed other equivalent typos. BC is taken into account.

## Test
Updated unit test