### PR TITLE
EZP-26325: JS client use query property

### DIFF
--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -1089,8 +1089,8 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      * @param callback {Function} callback executed after performing the request (see
      *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
      * @example
-     *     var viewCreateStruct = contentService.newViewCreateStruct('some-test-id');
-     *     viewCreateStruct.body.ViewInput.Query.Criteria = {
+     *     var viewCreateStruct = contentService.newViewCreateStruct('some-test-id', 'LocationQuery');
+     *     viewCreateStruct.body.ViewInput.LocationQuery.Query = {
      *         FullTextCriterion : "title"
      *     };
      *     contentService.createView(
@@ -1108,7 +1108,10 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
                     callback(error, views);
                     return;
                 }
-
+                if ( viewCreateStruct.getCriteria() && Object.keys(viewCreateStruct.getCriteria()).length !== 0 ) {
+                    console.warn('[DEPRECATED] virtual property Criteria is deprecated');
+                }
+                
                 that._connectionManager.request(
                     "POST",
                     views._href,

--- a/src/structures/ViewCreateStruct.js
+++ b/src/structures/ViewCreateStruct.js
@@ -23,6 +23,14 @@ define(function () {
             type = "ContentQuery";
         }
         /**
+         * Holds the view type 
+         *
+         * @property _type
+         * @protected
+         * @type {String}
+         */
+        this._type = type;
+        /**
          * Holds the body of the view create structs
          *
          * @property body
@@ -56,6 +64,93 @@ define(function () {
             "Accept": "application/vnd.ez.api.View+json; version=1.1",
             "Content-Type": "application/vnd.ez.api.ViewInput+json; version=1.1"
         };
+    };
+
+    /**
+     * Gets the Criteria property
+     *
+     * @method getCriteria
+     * @return {Object} the criteria property.
+     * @deprecated
+     */
+    ViewCreateStruct.prototype.getCriteria = function () {
+        return this.body.ViewInput[this._type].Criteria;
+    };
+
+    /**
+     * Gets the Query property
+     *
+     * @method getQuery
+     * @return {Object} the query property.
+     */
+    ViewCreateStruct.prototype.getQuery = function () {
+        return this.body.ViewInput[this._type].Query;
+    };
+
+    /**
+     * Gets the Filter property
+     *
+     * @method getFilter
+     * @return {Object} the Filter property.
+     */
+    ViewCreateStruct.prototype.getFilter = function () {
+        return this.body.ViewInput[this._type].Filter;
+    };
+
+    /**
+     * Sets the Criteria property
+     *
+     * @method setCriteria
+     * @deprecated
+     */
+    ViewCreateStruct.prototype.setCriteria = function (criteria) {
+        this.body.ViewInput[this._type].Criteria = criteria;
+    };
+
+    /**
+     * Sets the Query property
+     *
+     * @method setQuery
+     */
+    ViewCreateStruct.prototype.setQuery = function (query) {
+        this.body.ViewInput[this._type].Query = query;
+    };
+
+    /**
+     * Sets the Filter property
+     *
+     * @method setFilter
+     */
+    ViewCreateStruct.prototype.setFilter = function (filter) {
+        this.body.ViewInput[this._type].Filter = filter;
+    };
+
+    /**
+     * Sets the SortClauses property
+     *
+     * @method setSortClauses
+     */
+    ViewCreateStruct.prototype.setSortClauses = function (sortClauses) {
+        this.body.ViewInput[this._type].SortClauses = sortClauses;
+    };
+
+    /**
+     * Sets the FacetBuilders property
+     *
+     * @method setFacetBuilders
+     */
+    ViewCreateStruct.prototype.setFacetBuilders = function (facetBuilders) {
+        this.body.ViewInput[this._type].FacetBuilders = facetBuilders;
+    };
+
+    /**
+     * Sets the limit and offset properties
+     *
+     * @method setLimitAndOffset
+     */
+    ViewCreateStruct.prototype.setLimitAndOffset = function (limit, offset) {
+        this.body.ViewInput[this._type].limit = limit;
+        this.body.ViewInput[this._type].offset = offset;
     };
 
     return ViewCreateStruct;

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -221,6 +221,7 @@ define(function (require) {
                 };
 
                 spyOn(mockDiscoveryService, 'getInfoObject').andCallThrough();
+                spyOn(console, 'warn');
 
                 contentService = new ContentService(mockConnectionManager, mockDiscoveryService, rootId);
             });
@@ -247,7 +248,27 @@ define(function (require) {
                     viewCreateStruct,
                     mockCallback
                 );
+                expect(console.warn.callCount).toBe(0);
+                expect(mockDiscoveryService.getInfoObject).toHaveBeenCalledWith("views", jasmine.any(Function));
 
+                expect(mockConnectionManager.request).toHaveBeenCalledWith(
+                    "POST",
+                    testViews,
+                    JSON.stringify(viewCreateStruct.body),
+                    viewCreateStruct.headers,
+                    mockCallback
+                );
+            });
+
+            it("createView with a ViewCreateStruct having Criteria", function () {
+                var viewCreateStruct = contentService.newViewCreateStruct('some-test-id');
+
+                viewCreateStruct.body.ViewInput.ContentQuery.Criteria = {AnyCriterion: ''};
+                contentService.createView(
+                    viewCreateStruct,
+                    mockCallback
+                );
+                expect(console.warn.callCount).toBe(1);
                 expect(mockDiscoveryService.getInfoObject).toHaveBeenCalledWith("views", jasmine.any(Function));
 
                 expect(mockConnectionManager.request).toHaveBeenCalledWith(

--- a/test/ViewCreateStruct.tests.js
+++ b/test/ViewCreateStruct.tests.js
@@ -55,5 +55,97 @@ define(function (require) {
                 expect(viewInput.public).toEqual(false);
             });
         });
+        describe('getCriteria', function () {
+
+            it('should get Criteria property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput;
+
+                expect(struct.getCriteria()).toEqual(viewInput.ContentQuery.Criteria);
+            });
+        });
+        describe('getQuery', function () {
+
+            it('should get Query property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput;
+
+                expect(struct.getQuery()).toEqual(viewInput.ContentQuery.Query);
+            });
+        });
+        describe('getFilter', function () {
+
+            it('should get Filter property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput;
+
+                expect(struct.getFilter()).toEqual(viewInput.ContentQuery.Filter);
+            });
+        });
+        describe('setFilter', function () {
+
+            it('should set Filter property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    filter = {some: 'thing'};
+
+                struct.setFilter(filter);
+                expect(struct.getFilter()).toEqual(filter);
+            });
+        });
+        describe('setCriteria', function () {
+
+            it('should set Criteria property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    criteria = {some: 'thing'};
+
+                struct.setCriteria(criteria);
+                expect(struct.getCriteria()).toEqual(criteria);
+            });
+        });
+        describe('setQuery', function () {
+
+            it('should set Query property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    query = {some: 'thing'};
+
+                struct.setQuery(query);
+                expect(struct.getQuery()).toEqual(query);
+            });
+        });
+        describe('setSortClauses', function () {
+
+            it('should set SortClauses property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput,
+                    sortClauses = {some: 'thing'};
+
+                struct.setSortClauses(sortClauses);
+                expect(viewInput.ContentQuery.SortClauses).toEqual(sortClauses);
+            });
+        });
+        describe('setFacetBuilders', function () {
+
+            it('should set FacetBuilders property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput,
+                    facetBuilders = {some: 'thing'};
+
+                struct.setFacetBuilders(facetBuilders);
+                expect(viewInput.ContentQuery.FacetBuilders).toEqual(facetBuilders);
+            });
+        });
+        describe('setLimitAndOffset', function () {
+
+            it('should set Limit and Offset property', function () {
+                var struct = new ViewCreateStruct("my-view"),
+                    viewInput = struct.body.ViewInput,
+                    limit = 1,
+                    offset = 2;
+
+                struct.setLimitAndOffset(limit, offset);
+                expect(viewInput.ContentQuery.limit).toEqual(limit);
+                expect(viewInput.ContentQuery.offset).toEqual(offset);
+            });
+        });
     });
 });


### PR DESCRIPTION
jira : https://jira.ez.no/browse/EZP-26400
## Description

Goal here is to make the JS REST client able to use query and filter property instead of criteria ( now deprecated ). I also gave the viewCreateStruct some basic methods to be easier to use
## Tests

unit tested
