### PR TITLE
EZP-27100: Allow to pass custom XHR callbacks with REST requests

### DIFF
--- a/src/ConnectionManager.js
+++ b/src/ConnectionManager.js
@@ -33,41 +33,80 @@ define(["structures/Response", "structures/Request", "structures/CAPIError"],
      * @param [url="/"] {String} requested REST resource
      * @param [body=""] {String} a string which should be passed in request body to the REST service
      * @param [headers={}] {object} object literal describing request headers
+     * @param [requestEventHandlers] {Object} a set of callbacks to apply on a specific XHR event like onload, onerror, onprogress, etc.
      * @param callback {Function} function, which will be executed on request success
+     * @example
+     *      var connectionManager = jsCAPI.getConnectionManager();
+     *
+     *      connectionManager.request(
+     *          'GET',
+     *          '/endpoint',
+     *          '',
+     *          {Accept: 'application/json'},
+     *          {
+     *              upload: {
+     *                  onloadstart: someUploadCallback,
+     *                  onload: someUploadCallback,
+     *                  onloadend: someUploadCallback,
+     *                  onprogress: someUploadCallback,
+     *                  onabort: someUploadCallback,
+     *                  onerror: someUploadCallback,
+     *                  ontimeout: someUploadCallback,
+     *              },
+     *              onloadstart: someCallback,
+     *              onload: someCallback,
+     *              onloadend: someCallback,
+     *              onprogress: someCallback,
+     *              onabort: someCallback,
+     *              onerror: someCallback,
+     *              ontimeout: someCallback,
+     *          },
+     *          callback
+     *      );
      */
-    ConnectionManager.prototype.request = function (method, url, body, headers, callback) {
+    ConnectionManager.prototype.request = function (method, url, body, headers, requestEventHandlers, callback) {
         var that = this,
             request,
             nextRequest,
             defaultMethod = "GET",
             defaultUrl = "/",
             defaultBody = "",
-            defaultHeaders = {};
+            defaultHeaders = {},
+            defaultRequestEventHandlers = {};
 
         // default values for omitted parameters (if any)
-        if (arguments.length < 5) {
-            if (typeof method == "function") {
-                //no optional parameteres are passed
+        if (arguments.length < 6) {
+            if (typeof method === 'function') {
+                // no optional parameteres are passed
                 callback = method;
                 method = defaultMethod;
                 url = defaultUrl;
                 body = defaultBody;
                 headers = defaultHeaders;
-            } else if (typeof url == "function") {
+                requestEventHandlers = defaultRequestEventHandlers;
+            } else if (typeof url === 'function') {
                 // only first 1 optional parameter is passed
+                requestEventHandlers = body;
                 callback = url;
                 url = defaultUrl;
                 body = defaultBody;
                 headers = defaultHeaders;
-            } else if (typeof body == "function") {
+                requestEventHandlers = defaultRequestEventHandlers;
+            } else if (typeof body === 'function') {
                 // only first 2 optional parameters are passed
                 callback = body;
                 body = defaultBody;
                 headers = defaultHeaders;
-            } else {
+                requestEventHandlers = defaultRequestEventHandlers;
+            } else if (typeof headers === 'function') {
                 // only first 3 optional parameters are passed
                 callback = headers;
                 headers = defaultHeaders;
+                requestEventHandlers = defaultRequestEventHandlers;
+            } else if (typeof requestEventHandlers === 'function') {
+                // only first 4 optional parameters are passed
+                callback = requestEventHandlers;
+                requestEventHandlers = defaultRequestEventHandlers;
             }
         }
 
@@ -124,7 +163,7 @@ define(["structures/Response", "structures/Request", "structures/CAPIError"],
                                     console.dir(request);
                                 }
                                 // Main goal
-                                that._connectionFactory.createConnection().execute(authenticatedRequest, callback);
+                                that._connectionFactory.createConnection().execute(authenticatedRequest, requestEventHandlers, callback);
                             }
                         );
                     } // while

--- a/src/services/ContentService.js
+++ b/src/services/ContentService.js
@@ -388,11 +388,45 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
      *
      * @method createContent
      * @param contentCreateStruct {ContentCreateStruct} object describing content to be created
+     * @param [requestEventHandlers] {Object} a set of callbacks to apply on a specific XHR event like onload, onerror, onprogress, etc.
      * @param callback {Function} callback executed after performing the request (see
      *  {{#crossLink "ContentService"}}Note on the callbacks usage{{/crossLink}} for more info)
+     * @example
+     *      var contentService = jsCAPI.getContentService();
+     *
+     *      contentService.createContent(
+     *          {
+     *              body: '',
+     *              headers: {}
+     *          },
+     *          {
+     *              upload: {
+     *                  onloadstart: someUploadCallback,
+     *                  onload: someUploadCallback,
+     *                  onloadend: someUploadCallback,
+     *                  onprogress: someUploadCallback,
+     *                  onabort: someUploadCallback,
+     *                  onerror: someUploadCallback,
+     *                  ontimeout: someUploadCallback,
+     *              },
+     *              onloadstart: someCallback,
+     *              onload: someCallback,
+     *              onloadend: someCallback,
+     *              onprogress: someCallback,
+     *              onabort: someCallback,
+     *              onerror: someCallback,
+     *              ontimeout: someCallback,
+     *          },
+     *          callback
+     *      );
      */
-    ContentService.prototype.createContent = function (contentCreateStruct, callback) {
+    ContentService.prototype.createContent = function (contentCreateStruct, requestEventHandlers, callback) {
         var that = this;
+
+        if (typeof requestEventHandlers === 'function') {
+            callback = requestEventHandlers;
+            requestEventHandlers = {};
+        }
 
         this._discoveryService.getInfoObject(
             "content",
@@ -407,6 +441,7 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
                     contentObjects._href,
                     JSON.stringify(contentCreateStruct.body),
                     contentCreateStruct.headers,
+                    requestEventHandlers,
                     callback
                 );
             }
@@ -1111,7 +1146,7 @@ define(["structures/ContentCreateStruct", "structures/ContentUpdateStruct", "str
                 if ( viewCreateStruct.getCriteria() && Object.keys(viewCreateStruct.getCriteria()).length !== 0 ) {
                     console.warn('[DEPRECATED] virtual property Criteria is deprecated');
                 }
-                
+
                 that._connectionManager.request(
                     "POST",
                     views._href,

--- a/test/ConnectionManager.tests.js
+++ b/test/ConnectionManager.tests.js
@@ -88,6 +88,7 @@ define(function (require) {
                 expect(mockConnectionFactory.createConnection).toHaveBeenCalled();
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
 
@@ -117,6 +118,7 @@ define(function (require) {
                 );
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
                 expect(console.dir).toHaveBeenCalledWith(jasmine.any(Request));
@@ -143,6 +145,7 @@ define(function (require) {
                 );
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
 
@@ -169,6 +172,7 @@ define(function (require) {
                 );
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
 
@@ -196,6 +200,7 @@ define(function (require) {
                 );
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
 
@@ -204,6 +209,41 @@ define(function (require) {
                     url: endPointUrl + rootId,
                     body: "",
                     headers: {}
+                });
+            });
+
+            it("request (with 5 optional arguments)", function () {
+                var requestEventHandlers = {
+                        upload: { onerror: function () {}},
+                        onerror: function () {}
+                    },
+                    requestHeaders = {};
+
+                connectionManager.request(
+                    "GET",
+                    rootId,
+                    "",
+                    requestHeaders,
+                    requestEventHandlers,
+                    mockCallback
+                );
+
+                expect(mockAuthenticationAgent.ensureAuthentication).toHaveBeenCalled();
+                expect(mockAuthenticationAgent.authenticateRequest).toHaveBeenCalledWith(
+                    jasmine.any(Request),
+                    jasmine.any(Function)
+                );
+                expect(mockConnection.execute).toHaveBeenCalledWith(
+                    jasmine.any(Request),
+                    requestEventHandlers,
+                    mockCallback
+                );
+
+                expect(mockConnection.execute).toHaveBeenCalledWithObject({
+                    method: "GET",
+                    url: endPointUrl + rootId,
+                    body: "",
+                    headers: requestHeaders
                 });
             });
 
@@ -369,6 +409,7 @@ define(function (require) {
                 expect(mockConnectionFactory.createConnection).toHaveBeenCalled();
                 expect(mockConnection.execute).toHaveBeenCalledWith(
                     jasmine.any(Request),
+                    {},
                     mockCallback
                 );
 

--- a/test/ContentService.tests.js
+++ b/test/ContentService.tests.js
@@ -287,7 +287,6 @@ define(function (require) {
             describe("Content management request:", function () {
 
                 it("createContent", function () {
-
                     var locationCreateStruct = contentService.newLocationCreateStruct("/api/ezp/v2/content/locations/1/2/118"),
                         contentCreateStruct = contentService.newContentCreateStruct(
                             "/api/ezp/v2/content/types/18",
@@ -315,6 +314,45 @@ define(function (require) {
                         testContentObjects,
                         JSON.stringify(contentCreateStruct.body),
                         contentCreateStruct.headers,
+                        {},
+                        mockCallback
+                    );
+                });
+
+                it("createContent with optional request callbacks", function () {
+                    var locationCreateStruct = contentService.newLocationCreateStruct("/api/ezp/v2/content/locations/1/2/118"),
+                        contentCreateStruct = contentService.newContentCreateStruct(
+                            "/api/ezp/v2/content/types/18",
+                            locationCreateStruct,
+                            "eng-US",
+                            "DummyUser"
+                        ),
+                        fieldInfo = {
+                            "fieldDefinitionIdentifier": "title",
+                            "languageCode": "eng-US",
+                            "fieldValue": "This is a title"
+                        },
+                        requestCallbacks = {
+                            upload: {},
+                            onerror: function () {}
+                        };
+
+                    contentCreateStruct.body.ContentCreate.fields.field.push(fieldInfo);
+
+                    contentService.createContent(
+                        contentCreateStruct,
+                        requestCallbacks,
+                        mockCallback
+                    );
+
+                    expect(mockDiscoveryService.getInfoObject).toHaveBeenCalledWith("content", jasmine.any(Function));
+
+                    expect(mockConnectionManager.request).toHaveBeenCalledWith(
+                        "POST",
+                        testContentObjects,
+                        JSON.stringify(contentCreateStruct.body),
+                        contentCreateStruct.headers,
+                        requestCallbacks,
                         mockCallback
                     );
                 });

--- a/test/XmlHttpRequestConnection.tests.js
+++ b/test/XmlHttpRequestConnection.tests.js
@@ -145,6 +145,80 @@ define(function (require) {
 
         });
 
+        describe("is correctly using XmlHttpRequest and runs attached callbacks while performing:", function (){
+            beforeEach(function (){
+                mockXMLHttpRequest.prototype.send = function (body) {
+                    this.readyState = 4;
+                    this.status = 200;
+                    this.onloadstart();
+                    this.onload();
+                    this.onloadend();
+                    this.onprogress();
+                    this.ontimeout();
+                    this.onerror();
+                    this.onabort();
+                    this.upload.onloadstart();
+                    this.upload.onload();
+                    this.upload.onloadend();
+                    this.upload.onprogress();
+                    this.upload.ontimeout();
+                    this.upload.onerror();
+                    this.upload.onabort();
+                    this.onreadystatechange();
+                };
+                mockXMLHttpRequest.prototype.upload = {};
+                spyOn(mockXMLHttpRequest.prototype, 'send').andCallThrough();
+
+                window.XMLHttpRequest = (function () { return mockXMLHttpRequest; }());
+
+                connection = new XmlHttpRequestConnection();
+            });
+
+            it("execute call and invokes custom request event callbacks", function () {
+                var requestEventHandlers = {
+                    onreadystatechange: jasmine.createSpy('onreadystatechange'),
+                    onloadstart: jasmine.createSpy('onloadstart'),
+                    onload: jasmine.createSpy('onload'),
+                    onloadend: jasmine.createSpy('onloadend'),
+                    onprogress: jasmine.createSpy('onprogress'),
+                    ontimeout: jasmine.createSpy('ontimeout'),
+                    onerror: jasmine.createSpy('onerror'),
+                    onabort: jasmine.createSpy('onabort'),
+                    upload: {
+                        onloadstart: jasmine.createSpy('uploadOnloadstart'),
+                        onload: jasmine.createSpy('uploadOnload'),
+                        onloadend: jasmine.createSpy('uploadOnloadend'),
+                        onprogress: jasmine.createSpy('uploadOnprogress'),
+                        ontimeout: jasmine.createSpy('uploadOntimeout'),
+                        onerror: jasmine.createSpy('uploadOnerror'),
+                        onabort: jasmine.createSpy('uploadOnabort'),
+                    }
+                };
+
+                connection.execute(
+                    mockRequest,
+                    requestEventHandlers,
+                    mockCallback
+                );
+
+                expect(requestEventHandlers.onloadstart).toHaveBeenCalled();
+                expect(requestEventHandlers.onload).toHaveBeenCalled();
+                expect(requestEventHandlers.onloadend).toHaveBeenCalled();
+                expect(requestEventHandlers.ontimeout).toHaveBeenCalled();
+                expect(requestEventHandlers.onreadystatechange).not.toHaveBeenCalled();
+                expect(requestEventHandlers.onprogress).toHaveBeenCalled();
+                expect(requestEventHandlers.onabort).toHaveBeenCalled();
+                expect(requestEventHandlers.onerror).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onloadstart).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onload).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onloadend).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.ontimeout).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onprogress).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onabort).toHaveBeenCalled();
+                expect(requestEventHandlers.upload.onerror).toHaveBeenCalled();
+            });
+        });
+
         describe("is returning errors and retrying correctly, when ", function (){
 
             it("request is not finished yet", function (){

--- a/test/XmlHttpRequestConnection.tests.js
+++ b/test/XmlHttpRequestConnection.tests.js
@@ -145,78 +145,106 @@ define(function (require) {
 
         });
 
-        describe("is correctly using XmlHttpRequest and runs attached callbacks while performing:", function (){
-            beforeEach(function (){
-                mockXMLHttpRequest.prototype.send = function (body) {
-                    this.readyState = 4;
-                    this.status = 200;
-                    this.onloadstart();
-                    this.onload();
-                    this.onloadend();
-                    this.onprogress();
-                    this.ontimeout();
-                    this.onerror();
-                    this.onabort();
-                    this.upload.onloadstart();
-                    this.upload.onload();
-                    this.upload.onloadend();
-                    this.upload.onprogress();
-                    this.upload.ontimeout();
-                    this.upload.onerror();
-                    this.upload.onabort();
-                    this.onreadystatechange();
-                };
+        describe('register XmlHttpRequest event handler', function (){
+            beforeEach(function () {
                 mockXMLHttpRequest.prototype.upload = {};
-                spyOn(mockXMLHttpRequest.prototype, 'send').andCallThrough();
-
                 window.XMLHttpRequest = (function () { return mockXMLHttpRequest; }());
 
                 connection = new XmlHttpRequestConnection();
             });
 
-            it("execute call and invokes custom request event callbacks", function () {
-                var requestEventHandlers = {
-                    onreadystatechange: jasmine.createSpy('onreadystatechange'),
-                    onloadstart: jasmine.createSpy('onloadstart'),
-                    onload: jasmine.createSpy('onload'),
-                    onloadend: jasmine.createSpy('onloadend'),
-                    onprogress: jasmine.createSpy('onprogress'),
-                    ontimeout: jasmine.createSpy('ontimeout'),
-                    onerror: jasmine.createSpy('onerror'),
-                    onabort: jasmine.createSpy('onabort'),
-                    upload: {
-                        onloadstart: jasmine.createSpy('uploadOnloadstart'),
-                        onload: jasmine.createSpy('uploadOnload'),
-                        onloadend: jasmine.createSpy('uploadOnloadend'),
-                        onprogress: jasmine.createSpy('uploadOnprogress'),
-                        ontimeout: jasmine.createSpy('uploadOntimeout'),
-                        onerror: jasmine.createSpy('uploadOnerror'),
-                        onabort: jasmine.createSpy('uploadOnabort'),
+            function testEventHandler(eventHandlerName, isAllowed) {
+                var eventHandler = function () {},
+                    events = {};
+
+                isAllowed = typeof isAllowed === 'undefined' ? true : isAllowed;
+
+                events[eventHandlerName] = eventHandler;
+
+                mockXMLHttpRequest.prototype.send = function () {
+                    if (isAllowed) {
+                        expect(this[eventHandlerName]).toBe(eventHandler);
+                    } else {
+                        expect(this[eventHandlerName]).not.toBe(eventHandler);
                     }
                 };
 
-                connection.execute(
-                    mockRequest,
-                    requestEventHandlers,
-                    mockCallback
-                );
+                connection.execute(mockRequest, events, mockCallback);
+            }
 
-                expect(requestEventHandlers.onloadstart).toHaveBeenCalled();
-                expect(requestEventHandlers.onload).toHaveBeenCalled();
-                expect(requestEventHandlers.onloadend).toHaveBeenCalled();
-                expect(requestEventHandlers.ontimeout).toHaveBeenCalled();
-                expect(requestEventHandlers.onreadystatechange).not.toHaveBeenCalled();
-                expect(requestEventHandlers.onprogress).toHaveBeenCalled();
-                expect(requestEventHandlers.onabort).toHaveBeenCalled();
-                expect(requestEventHandlers.onerror).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onloadstart).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onload).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onloadend).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.ontimeout).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onprogress).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onabort).toHaveBeenCalled();
-                expect(requestEventHandlers.upload.onerror).toHaveBeenCalled();
+            function testUploadEventHandler(eventHandlerName) {
+                var eventHandler = function () {},
+                    events = {upload: {}};
+
+                events.upload[eventHandlerName] = eventHandler;
+
+                mockXMLHttpRequest.prototype.send = function () {
+                    expect(this.upload[eventHandlerName]).toBe(eventHandler);
+                };
+                connection.execute(mockRequest, events, mockCallback);
+            }
+
+            it('should register onloadstart event handler', function () {
+                testEventHandler('onloadstart');
             });
+
+            it('should register onload event handler', function () {
+                testEventHandler('onload');
+            });
+
+            it('should register onloadend event handler', function () {
+                testEventHandler('onloadend');
+            });
+
+            it('should register onprogress event handler', function () {
+                testEventHandler('onprogress');
+            });
+
+            it('should register ontimeout event handler', function () {
+                testEventHandler('ontimeout');
+            });
+
+            it('should register onerror event handler', function () {
+                testEventHandler('onerror');
+            });
+
+            it('should register onabort event handler', function () {
+                testEventHandler('onabort');
+            });
+
+            it('should register onreadystatechange event handler', function () {
+                testEventHandler('onreadystatechange', false);
+            });
+
+            it('should register upload onloadstart event handler', function () {
+                testUploadEventHandler('onloadstart');
+            });
+
+            it('should register upload onload event handler', function () {
+                testUploadEventHandler('onload');
+            });
+
+            it('should register upload onloadend event handler', function () {
+                testUploadEventHandler('onloadend');
+            });
+
+            it('should register upload onprogress event handler', function () {
+                testUploadEventHandler('onprogress');
+            });
+
+            it('should register upload ontimeout event handler', function () {
+                testUploadEventHandler('ontimeout');
+            });
+
+            it('should register upload onerror event handler', function () {
+                testUploadEventHandler('onerror');
+            });
+
+            it('should register upload onabort event handler', function () {
+                testUploadEventHandler('onabort');
+            });
+
+
         });
 
         describe("is returning errors and retrying correctly, when ", function (){


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-27100

The `ConnectionManager` takes an additional param in the `request()` method. It's the `xhrCallbacks` param.

The param should be an object having the structure similar to this:
```javascript
{
    upload: {
        onloadstart: function () {},
        onload: function () {},
        onloadend: function () {},
        onprogress: function () {},
        onabort: function () {},
        onerror: function () {},
        ontimeout: function () {},
    },
    onloadstart: function () {},
    onload: function () {},
    onloadend: function () {},
    onprogress: function () {},
    onabort: function () {},
    onerror: function () {},
    ontimeout: function () {},
}
```

The `xhrCallbacks.upload` object contains callbacks applied to the `XMLHttpRequestUpload` object instance, while the first-level callbacks are applied to the `XMLHttpRequest` object instance.

The upload callbacks are especially useful when dealing with POST requests, where a lot of data posted with them.

The additional callbacks param has been added to many places so user can track a progress of every action provided by the JS REST Client.